### PR TITLE
Add `FileSystem.path`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+#### 1.0.2
+
+* Improved `toString` implementations in file system entity classes
+* Added `ForwardingFileSystem` and associated forwarding classes to the
+  main `file` library.
+* Removed `FileSystem.pathSeparator`, and added a more comprehensive
+  `FileSystem.path` property.
+
 #### 1.0.1
 
 * Added `FileSystem.systemTempDirectory`

--- a/lib/src/backends/chroot/chroot_file_system.dart
+++ b/lib/src/backends/chroot/chroot_file_system.dart
@@ -69,7 +69,8 @@ class ChrootFileSystem extends FileSystem {
   Link link(path) => new _ChrootLink(this, common.getPath(path));
 
   @override
-  String get pathSeparator => delegate.pathSeparator;
+  p.Context get path =>
+      new p.Context(style: delegate.path.style, current: _cwd);
 
   /// Gets the system temp directory. This directory will be created on-demand
   /// in the local root of the file system. Once created, its location is fixed

--- a/lib/src/backends/local.dart
+++ b/lib/src/backends/local.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'package:file/src/forwarding.dart';
 import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
+import 'package:path/path.dart' as p;
 
 import '../io/shim.dart' as shim;
 

--- a/lib/src/backends/local/local_file_system.dart
+++ b/lib/src/backends/local/local_file_system.dart
@@ -22,7 +22,7 @@ class LocalFileSystem extends FileSystem {
   Link link(path) => new _LocalLink(this, shim.newLink(path));
 
   @override
-  String get pathSeparator => shim.pathSeparator;
+  p.Context get path => new p.Context();
 
   /// Gets the directory provided by the operating system for creating temporary
   /// files and directories in. The location of the system temp directory is

--- a/lib/src/backends/memory/memory_directory.dart
+++ b/lib/src/backends/memory/memory_directory.dart
@@ -49,9 +49,9 @@ class _MemoryDirectory extends _MemoryFileSystemEntity implements Directory {
   @override
   Directory createTempSync([String prefix]) {
     prefix = (prefix ?? '') + 'rand';
-    String fullPath = fileSystem._context.join(path, prefix);
-    String dirname = fileSystem._context.dirname(fullPath);
-    String basename = fileSystem._context.basename(fullPath);
+    String fullPath = fileSystem.path.join(path, prefix);
+    String dirname = fileSystem.path.dirname(fullPath);
+    String basename = fileSystem.path.basename(fullPath);
     _DirectoryNode node = fileSystem._findNode(dirname);
     _checkExists(node, () => dirname);
     _checkIsDir(node, () => dirname);
@@ -62,7 +62,7 @@ class _MemoryDirectory extends _MemoryFileSystemEntity implements Directory {
     _DirectoryNode tempDir = new _DirectoryNode(node);
     node.children[name()] = tempDir;
     return new _MemoryDirectory(
-        fileSystem, fileSystem._context.join(dirname, name()));
+        fileSystem, fileSystem.path.join(dirname, name()));
   }
 
   @override
@@ -113,7 +113,7 @@ class _MemoryDirectory extends _MemoryFileSystemEntity implements Directory {
       _PendingListTask task = tasks.removeLast();
       task.dir.children.forEach((String name, _Node child) {
         Set<_LinkNode> breadcrumbs = new Set<_LinkNode>.from(task.breadcrumbs);
-        String childPath = fileSystem._context.join(task.path, name);
+        String childPath = fileSystem.path.join(task.path, name);
         while (followLinks && _isLink(child) && breadcrumbs.add(child)) {
           _Node referent = (child as _LinkNode).referentOrNull;
           if (referent != null) {

--- a/lib/src/backends/memory/memory_file_system.dart
+++ b/lib/src/backends/memory/memory_file_system.dart
@@ -65,7 +65,7 @@ class MemoryFileSystem extends FileSystem {
   Link link(path) => new _MemoryLink(this, common.getPath(path));
 
   @override
-  String get pathSeparator => _separator;
+  p.Context get path => new p.Context(style: p.Style.posix, current: _cwd);
 
   /// Gets the system temp directory. This directory will be created on-demand
   /// in the root of the file system. Once created, its location is fixed for
@@ -146,9 +146,6 @@ class MemoryFileSystem extends FileSystem {
     }
     return node.type;
   }
-
-  /// Gets the path context for this file system given the current working dir.
-  p.Context get _context => new p.Context(style: p.Style.posix, current: _cwd);
 
   /// Gets the node backing for the current working directory. Note that this
   /// can return null if the directory has been deleted or moved from under our

--- a/lib/src/backends/memory/memory_file_system_entity.dart
+++ b/lib/src/backends/memory/memory_file_system_entity.dart
@@ -22,10 +22,10 @@ abstract class _MemoryFileSystemEntity implements FileSystemEntity {
   _MemoryFileSystemEntity(this.fileSystem, this.path);
 
   /// Gets the part of this entity's path before the last separator.
-  String get dirname => fileSystem._context.dirname(path);
+  String get dirname => fileSystem.path.dirname(path);
 
   /// Gets the part of this entity's path after the last separator.
-  String get basename => fileSystem._context.basename(path);
+  String get basename => fileSystem.path.basename(path);
 
   /// Returns the expected type of this entity, which may differ from the type
   /// of the node that's found at the path specified by this entity.
@@ -95,7 +95,7 @@ abstract class _MemoryFileSystemEntity implements FileSystemEntity {
     if (!_isAbsolute(resolved)) {
       resolved = fileSystem._cwd + _separator + resolved;
     }
-    return fileSystem._context.normalize(resolved);
+    return fileSystem.path.normalize(resolved);
   }
 
   @override
@@ -127,7 +127,7 @@ abstract class _MemoryFileSystemEntity implements FileSystemEntity {
   FileSystemEntity get absolute {
     String absolutePath = path;
     if (!_isAbsolute(absolutePath)) {
-      absolutePath = fileSystem._context.join(fileSystem._cwd, absolutePath);
+      absolutePath = fileSystem.path.join(fileSystem._cwd, absolutePath);
     }
     return _clone(absolutePath);
   }

--- a/lib/src/forwarding.dart
+++ b/lib/src/forwarding.dart
@@ -10,6 +10,7 @@ import 'dart:convert';
 import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
 
 part 'forwarding/forwarding_directory.dart';
 part 'forwarding/forwarding_file.dart';

--- a/lib/src/forwarding/forwarding_file_system.dart
+++ b/lib/src/forwarding/forwarding_file_system.dart
@@ -24,7 +24,7 @@ abstract class ForwardingFileSystem extends FileSystem {
   Link link(path) => delegate.link(path);
 
   @override
-  String get pathSeparator => delegate.pathSeparator;
+  p.Context get path => delegate.path;
 
   @override
   Directory get systemTempDirectory => delegate.systemTempDirectory;

--- a/lib/src/interface.dart
+++ b/lib/src/interface.dart
@@ -7,6 +7,8 @@ library file.src.interface;
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:path/path.dart' as path;
+
 import 'io.dart' as io;
 
 export 'io.dart';

--- a/lib/src/interface/file_system.dart
+++ b/lib/src/interface/file_system.dart
@@ -28,9 +28,8 @@ abstract class FileSystem {
   /// [path] can be either a [`String`], a [`Uri`], or a [`FileSystemEntity`].
   Link link(path);
 
-  /// Gets the path separator used by this file system to separate components
-  /// in file paths.
-  String get pathSeparator;
+  /// An object for manipulating paths in this file system.
+  path.Context get path;
 
   /// Gets the system temp directory.
   ///

--- a/lib/src/io/shim_dart_io.dart
+++ b/lib/src/io/shim_dart_io.dart
@@ -11,7 +11,6 @@ import 'package:file/src/common.dart' as common;
 io.Directory newDirectory(path) => new io.Directory(common.getPath(path));
 io.File newFile(path) => new io.File(common.getPath(path));
 io.Link newLink(path) => new io.Link(common.getPath(path));
-String get pathSeparator => io.Platform.pathSeparator;
 io.Directory systemTemp() => io.Directory.systemTemp;
 io.Directory get currentDirectory => io.Directory.current;
 set currentDirectory(dynamic path) => io.Directory.current = path;

--- a/lib/src/io/shim_internal.dart
+++ b/lib/src/io/shim_internal.dart
@@ -12,7 +12,6 @@ dynamic _requiresIO() => throw new UnsupportedError(_requiresIOMsg);
 io.Directory newDirectory(_) => _requiresIO();
 io.File newFile(_) => _requiresIO();
 io.Link newLink(_) => _requiresIO();
-String get pathSeparator => _requiresIO();
 io.Directory systemTemp() => _requiresIO();
 io.Directory get currentDirectory => _requiresIO();
 set currentDirectory(dynamic _) => _requiresIO();

--- a/test/common_tests.dart
+++ b/test/common_tests.dart
@@ -124,9 +124,13 @@ void runCommonTests(
         });
       });
 
-      group('pathSeparator', () {
-        test('isAmongExpectedValues', () {
-          expect(fs.pathSeparator, anyOf('/', r'\'));
+      group('path', () {
+        test('hasCorrectCurrentWorkingDirectory', () {
+          expect(fs.path.current, fs.currentDirectory.path);
+        });
+
+        test('separatorIsAmongExpectedValues', () {
+          expect(fs.path.separator, anyOf('/', r'\'));
         });
       });
 


### PR DESCRIPTION
Remove `FileSystem.pathSeparator`, since it can now be expressed
as `fileSystem.path.separator`.

Fixes #9