### PR TITLE
Add ResultReference<T> to record_replay library.

### DIFF
--- a/lib/src/backends/record_replay/common.dart
+++ b/lib/src/backends/record_replay/common.dart
@@ -21,3 +21,13 @@ String getSymbolName(Symbol symbol) {
   int offset = str.indexOf('"') + 1;
   return str.substring(offset, str.indexOf('"', offset));
 }
+
+/// This class is a work-around for the "is" operator not accepting a variable
+/// value as its right operand (https://github.com/dart-lang/sdk/issues/27680).
+class TypeMatcher<T> {
+  /// Creates a type matcher for the given type parameter.
+  const TypeMatcher();
+
+  /// Returns `true` if the given object is of type `T`.
+  bool matches(dynamic object) => object is T;
+}

--- a/lib/src/backends/record_replay/mutable_recording.dart
+++ b/lib/src/backends/record_replay/mutable_recording.dart
@@ -14,28 +14,45 @@ import 'recording.dart';
 
 /// A mutable live recording.
 class MutableRecording implements LiveRecording {
-  final List<InvocationEvent<dynamic>> _events = <InvocationEvent<dynamic>>[];
-
   /// Creates a new `MutableRecording` that will serialize its data to the
   /// specified [destination].
   MutableRecording(this.destination);
+
+  final List<LiveInvocationEvent<dynamic>> _events =
+      <LiveInvocationEvent<dynamic>>[];
+
+  bool _flushing = false;
 
   @override
   final Directory destination;
 
   @override
-  List<InvocationEvent<dynamic>> get events =>
-      new List<InvocationEvent<dynamic>>.unmodifiable(_events);
+  List<LiveInvocationEvent<dynamic>> get events =>
+      new List<LiveInvocationEvent<dynamic>>.unmodifiable(_events);
 
-  // TODO(tvolkert): Add ability to wait for all Future and Stream results
   @override
-  Future<Null> flush() async {
-    Directory dir = destination;
-    String json = new JsonEncoder.withIndent('  ', encode).convert(_events);
-    String filename = dir.fileSystem.path.join(dir.path, kManifestName);
-    await dir.fileSystem.file(filename).writeAsString(json, flush: true);
+  Future<Null> flush({Duration awaitPendingResults}) async {
+    if (_flushing) {
+      throw new StateError('Recording is already flushing');
+    }
+    _flushing = true;
+    try {
+      if (awaitPendingResults != null) {
+        Iterable<Future<Null>> futures =
+            _events.map((LiveInvocationEvent<dynamic> event) => event.done);
+        await Future
+            .wait<String>(futures)
+            .timeout(awaitPendingResults, onTimeout: () {});
+      }
+      Directory dir = destination;
+      String json = new JsonEncoder.withIndent('  ', encode).convert(_events);
+      String filename = dir.fileSystem.path.join(dir.path, kManifestName);
+      await dir.fileSystem.file(filename).writeAsString(json, flush: true);
+    } finally {
+      _flushing = false;
+    }
   }
 
   /// Adds the specified [event] to this recording.
-  void add(InvocationEvent<dynamic> event) => _events.add(event);
+  void add(LiveInvocationEvent<dynamic> event) => _events.add(event);
 }

--- a/lib/src/backends/record_replay/recording.dart
+++ b/lib/src/backends/record_replay/recording.dart
@@ -35,9 +35,20 @@ abstract class LiveRecording extends Recording {
   /// Writes this recording to disk.
   ///
   /// Live recordings will *not* call `flush` on themselves, so it is up to
-  /// callers to call this method when they wish to write the recording to disk.
+  /// callers to call this method when they wish to write the recording to
+  /// disk.
+  ///
+  /// If [awaitPendingResults] is specified, this will wait the specified
+  /// duration for any results that are `Future`s or `Stream`s to complete
+  /// before serializing the recording to disk. Futures that don't complete
+  /// within the specified duration will have their results recorded as `null`,
+  /// and streams that don't send a "done" event within the specified duration
+  /// will have their results recorded as the list of events the stream has
+  /// fired thus far.
+  ///
+  /// Throws a [StateError] if a flush is already in progress.
   ///
   /// Returns a future that completes once the recording has been fully written
   /// to disk.
-  Future<Null> flush();
+  Future<Null> flush({Duration awaitPendingResults});
 }

--- a/lib/src/backends/record_replay/result_reference.dart
+++ b/lib/src/backends/record_replay/result_reference.dart
@@ -1,0 +1,152 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'encoding.dart';
+import 'events.dart';
+import 'recording_proxy_mixin.dart';
+
+/// Wraps a raw invocation return value for the purpose of recording.
+///
+/// This class is intended for use with [RecordingProxyMixin]. Mixin subclasses
+/// may configure a method or getter to return a [ResultReference] rather than
+/// a raw result, and:
+///
+///   - [RecordingProxyMixin] will automatically return the reference's [value]
+///     to callers (as if the mixin subclass had returned the raw value
+///     directly).
+///   - The recording's [InvocationEvent] will automatically record the
+///     reference's [recordedValue].
+///   - The recording's serialized value (written out during
+///     [LiveRecording.flush]) will automatically serialize the reference's
+///     [serializedValue].
+abstract class ResultReference<T> {
+  /// Creates a new `ResultReference`.
+  const ResultReference();
+
+  /// The raw value to return to callers of the method or getter.
+  T get value;
+
+  /// The value to record in the recording's [InvocationEvent].
+  dynamic get recordedValue;
+
+  /// A JSON-serializable representation of this result, suitable for
+  /// encoding in a recording manifest.
+  ///
+  /// The value of this property will be one of the JSON-native types: `num`,
+  /// `String`, `bool`, `Null`, `List`, or `Map`.
+  ///
+  /// This allows for method-specific encoding routines. Take, for example, the
+  /// case of a method that returns `List<int>`. This type is natively
+  /// serializable by `JSONEncoder`, so if the raw value were directly returned
+  /// from an invocation, the recording would happily serialize the result as
+  /// a list of integers. However, the method may want to serialize the return
+  /// value differently, such as by writing it to file (if it knows the list is
+  /// actually a byte array that was read from a file). In this case, the
+  /// method can return a `ResultReference` to the list, and it will have a
+  /// hook into the serialization process.
+  dynamic get serializedValue => encode(recordedValue);
+
+  /// A [Future] that completes when [value] has completed.
+  ///
+  /// If [value] is a [Future], this future will complete when [value] has
+  /// completed. If [value] is a [Stream], this future will complete when the
+  /// stream sends a "done" event. If value is neither a future nor a stream,
+  /// this future will complete immediately.
+  Future<Null> get complete => new Future<Null>.value();
+}
+
+/// Wraps a future result.
+class FutureReference<T> extends ResultReference<Future<T>> {
+  final Future<T> _future;
+  T _value;
+
+  /// Creates a new `FutureReference` that wraps the specified [future].
+  FutureReference(Future<T> future) : _future = future;
+
+  /// The future value to return to callers of the method or getter.
+  @override
+  Future<T> get value {
+    return _future.then(
+      (T value) {
+        _value = value;
+        return value;
+      },
+      onError: (dynamic error) {
+        // TODO(tvolkert): Record errors
+        throw error;
+      },
+    );
+  }
+
+  /// The value returned by the completion of the future.
+  ///
+  /// If the future threw an error, this value will be `null`.
+  @override
+  T get recordedValue => _value;
+
+  @override
+  Future<Null> get complete => value;
+}
+
+/// Wraps a stream result.
+class StreamReference<T> extends ResultReference<Stream<T>> {
+  final Stream<T> _stream;
+  final StreamController<T> _controller;
+  final Completer<Null> _completer = new Completer<Null>();
+  final List<T> _data = <T>[];
+  StreamSubscription<T> _subscription;
+
+  /// Creates a new `StreamReference` that wraps the specified [stream].
+  StreamReference(Stream<T> stream)
+      : _stream = stream,
+        _controller = stream.isBroadcast
+            ? new StreamController<T>.broadcast()
+            : new StreamController<T>() {
+    _controller.onListen = () {
+      assert(_subscription == null);
+      _subscription = _listenToStream();
+    };
+    _controller.onCancel = () async {
+      assert(_subscription != null);
+      await _subscription.cancel();
+      _subscription = null;
+    };
+    _controller.onPause = () {
+      assert(_subscription != null && !_subscription.isPaused);
+      _subscription.pause();
+    };
+    _controller.onResume = () {
+      assert(_subscription != null && _subscription.isPaused);
+      _subscription.resume();
+    };
+  }
+
+  StreamSubscription<T> _listenToStream() {
+    return _stream.listen(
+      (T element) {
+        _data.add(element);
+        _controller.add(element);
+      },
+      onError: (dynamic error, StackTrace stackTrace) {
+        // TODO(tvolkert): Record errors
+        _controller.addError(error, stackTrace);
+      },
+      onDone: () {
+        _completer.complete();
+        _controller.close();
+      },
+    );
+  }
+
+  @override
+  Stream<T> get value => _controller.stream;
+
+  @override
+  List<T> get recordedValue => _data;
+
+  @override
+  Future<Null> get complete => _completer.future;
+}


### PR DESCRIPTION
This introduces a level of indirection that will allow
recording objects to differentiate between the invocation
result return value, the recorded result value, and the
serialized result value.

This is used to provide "special handling" of certain
invocation results (such as byte arrays) to make recordings
more human-readable & editable.

This design also yields more technical correctness over
the previous design. This is because we used to delay
recording an invocation whose result was a Future until
that future completed. Now, we record the invocation
immediately and late-record future results (with support
for awaiting those futures when serializing a recoridng).

Another step in #11