### PR TITLE
Serialize results of certain file invocations to separate file.

### DIFF
--- a/lib/src/backends/record_replay/mutable_recording.dart
+++ b/lib/src/backends/record_replay/mutable_recording.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:file/file.dart';
+import 'package:intl/intl.dart';
 
 import 'common.dart';
 import 'encoding.dart';
@@ -51,6 +52,20 @@ class MutableRecording implements LiveRecording {
     } finally {
       _flushing = false;
     }
+  }
+
+  /// Returns a new file for use with this recording.
+  ///
+  /// The file name will combine the specified [name] with [newUid] to ensure
+  /// that its name is unique among all recording files.
+  ///
+  /// It is up to the caller to create the file - it will not exist in the
+  /// file system when it is returned from this method.
+  File newFile(String name) {
+    String basename = '${new NumberFormat('000').format(newUid())}.$name';
+    String dirname = destination.path;
+    String path = destination.fileSystem.path.join(dirname, basename);
+    return destination.fileSystem.file(path);
   }
 
   /// Adds the specified [event] to this recording.

--- a/lib/src/backends/record_replay/mutable_recording.dart
+++ b/lib/src/backends/record_replay/mutable_recording.dart
@@ -42,7 +42,7 @@ class MutableRecording implements LiveRecording {
         Iterable<Future<Null>> futures =
             _events.map((LiveInvocationEvent<dynamic> event) => event.done);
         await Future
-            .wait<String>(futures)
+            .wait<Null>(futures)
             .timeout(awaitPendingResults, onTimeout: () {});
       }
       Directory dir = destination;

--- a/lib/src/backends/record_replay/recording_file.dart
+++ b/lib/src/backends/record_replay/recording_file.dart
@@ -181,10 +181,12 @@ class _ByteArrayFutureReference extends FutureReference<List<int>> {
         super(future);
 
   @override
-  Future<List<int>> get value => super.value.then((List<int> bytes) async {
-        await file.writeAsBytes(bytes, flush: true);
-        return bytes;
-      });
+  Future<List<int>> get value {
+    return super.value.then((List<int> bytes) async {
+      await file.writeAsBytes(bytes, flush: true);
+      return bytes;
+    });
+  }
 
   @override
   dynamic get serializedValue => '!${file.basename}';
@@ -219,10 +221,12 @@ class _FileContentFutureReference extends FutureReference<String> {
         super(future);
 
   @override
-  Future<String> get value => super.value.then((String content) async {
-        await file.writeAsString(content, flush: true);
-        return content;
-      });
+  Future<String> get value {
+    return super.value.then((String content) async {
+      await file.writeAsString(content, flush: true);
+      return content;
+    });
+  }
 
   @override
   dynamic get serializedValue => '!${file.basename}';
@@ -257,11 +261,12 @@ class _LinesFutureReference extends FutureReference<List<String>> {
         super(future);
 
   @override
-  Future<List<String>> get value =>
-      super.value.then((List<String> lines) async {
-        await file.writeAsString(lines.join('\n'), flush: true);
-        return lines;
-      });
+  Future<List<String>> get value {
+    return super.value.then((List<String> lines) async {
+      await file.writeAsString(lines.join('\n'), flush: true);
+      return lines;
+    });
+  }
 
   @override
   dynamic get serializedValue => '!${file.basename}';

--- a/lib/src/backends/record_replay/recording_file.dart
+++ b/lib/src/backends/record_replay/recording_file.dart
@@ -166,9 +166,10 @@ class _ByteArrayStreamReference extends StreamReference<List<int>> {
   @override
   dynamic get serializedValue => '!${file.basename}';
 
+  // TODO(tvolkert): remove `.then()` once Dart 1.22 is in stable
   @override
   Future<Null> get complete =>
-      Future.wait(<Future<dynamic>>[super.complete, _sink.done]);
+      Future.wait(<Future<dynamic>>[super.complete, _sink.done]).then((_) {});
 }
 
 class _ByteArrayFutureReference extends FutureReference<List<int>> {

--- a/lib/src/backends/record_replay/recording_file.dart
+++ b/lib/src/backends/record_replay/recording_file.dart
@@ -8,10 +8,12 @@ import 'dart:convert';
 import 'package:file/file.dart';
 import 'package:file/src/io.dart' as io;
 
+import 'mutable_recording.dart';
 import 'recording_file_system.dart';
 import 'recording_file_system_entity.dart';
 import 'recording_io_sink.dart';
 import 'recording_random_access_file.dart';
+import 'result_reference.dart';
 
 /// [File] implementation that records all invocation activity to its file
 /// system's recording.
@@ -31,14 +33,14 @@ class RecordingFile extends RecordingFileSystemEntity<File, io.File>
       #lastModifiedSync: delegate.lastModifiedSync,
       #open: _open,
       #openSync: _openSync,
-      #openRead: delegate.openRead,
+      #openRead: _openRead,
       #openWrite: _openWrite,
-      #readAsBytes: delegate.readAsBytes,
-      #readAsBytesSync: delegate.readAsBytesSync,
-      #readAsString: delegate.readAsString,
-      #readAsStringSync: delegate.readAsStringSync,
-      #readAsLines: delegate.readAsLines,
-      #readAsLinesSync: delegate.readAsLinesSync,
+      #readAsBytes: _readAsBytes,
+      #readAsBytesSync: _readAsBytesSync,
+      #readAsString: _readAsString,
+      #readAsStringSync: _readAsStringSync,
+      #readAsLines: _readAsLines,
+      #readAsLinesSync: _readAsLinesSync,
       #writeAsBytes: _writeAsBytes,
       #writeAsBytesSync: delegate.writeAsBytesSync,
       #writeAsString: _writeAsString,
@@ -65,12 +67,59 @@ class RecordingFile extends RecordingFileSystemEntity<File, io.File>
   RandomAccessFile _openSync({FileMode mode: FileMode.READ}) =>
       _wrapRandomAccessFile(delegate.openSync(mode: mode));
 
+  StreamReference<List<int>> _openRead([int start, int end]) =>
+      new _ByteArrayStreamReference(
+        recording,
+        'openRead',
+        delegate.openRead(start, end),
+      );
+
   IOSink _openWrite({FileMode mode: FileMode.WRITE, Encoding encoding: UTF8}) {
     return new RecordingIOSink(
       fileSystem,
       delegate.openWrite(mode: mode, encoding: encoding),
     );
   }
+
+  FutureReference<List<int>> _readAsBytes() => new _ByteArrayFutureReference(
+        recording,
+        'readAsBytes',
+        delegate.readAsBytes(),
+      );
+
+  ResultReference<List<int>> _readAsBytesSync() => new _ByteArrayReference(
+        recording,
+        'readAsBytesSync',
+        delegate.readAsBytesSync(),
+      );
+
+  FutureReference<String> _readAsString({Encoding encoding: UTF8}) =>
+      new _FileContentFutureReference(
+        recording,
+        'readAsString',
+        delegate.readAsString(encoding: encoding),
+      );
+
+  ResultReference<String> _readAsStringSync({Encoding encoding: UTF8}) =>
+      new _FileContentReference(
+        recording,
+        'readAsStringSync',
+        delegate.readAsStringSync(encoding: encoding),
+      );
+
+  FutureReference<List<String>> _readAsLines({Encoding encoding: UTF8}) =>
+      new _LinesFutureReference(
+        recording,
+        'readAsLines',
+        delegate.readAsLines(encoding: encoding),
+      );
+
+  ResultReference<List<String>> _readAsLinesSync({Encoding encoding: UTF8}) =>
+      new _LinesReference(
+        recording,
+        'readAsLinesSync',
+        delegate.readAsLinesSync(encoding: encoding),
+      );
 
   Future<File> _writeAsBytes(
     List<int> bytes, {
@@ -88,4 +137,151 @@ class RecordingFile extends RecordingFileSystemEntity<File, io.File>
       delegate
           .writeAsString(contents, mode: mode, encoding: encoding, flush: flush)
           .then(wrap);
+}
+
+class _ByteArrayStreamReference extends StreamReference<List<int>> {
+  final File file;
+  IOSink _sink;
+
+  _ByteArrayStreamReference(
+      MutableRecording recording, String name, Stream<List<int>> stream)
+      : file = recording.newFile(name)..createSync(),
+        super(stream);
+
+  @override
+  void onData(List<int> event) {
+    if (_sink == null) {
+      _sink = file.openWrite();
+    }
+    _sink.add(event);
+  }
+
+  @override
+  void onDone() {
+    if (_sink != null) {
+      _sink.close();
+    }
+  }
+
+  @override
+  dynamic get serializedValue => '!${file.basename}';
+
+  @override
+  Future<Null> get complete =>
+      Future.wait(<Future<dynamic>>[super.complete, _sink.done]);
+}
+
+class _ByteArrayFutureReference extends FutureReference<List<int>> {
+  final File file;
+
+  _ByteArrayFutureReference(
+      MutableRecording recording, String name, Future<List<int>> future)
+      : file = recording.newFile(name),
+        super(future);
+
+  @override
+  Future<List<int>> get value => super.value.then((List<int> bytes) async {
+        await file.writeAsBytes(bytes, flush: true);
+        return bytes;
+      });
+
+  @override
+  dynamic get serializedValue => '!${file.basename}';
+}
+
+class _ByteArrayReference extends ResultReference<List<int>> {
+  final File file;
+  final List<int> bytes;
+
+  _ByteArrayReference(MutableRecording recording, String name, this.bytes)
+      : file = recording.newFile(name);
+
+  @override
+  List<int> get value {
+    file.writeAsBytesSync(bytes, flush: true);
+    return bytes;
+  }
+
+  @override
+  List<int> get recordedValue => bytes;
+
+  @override
+  dynamic get serializedValue => '!${file.basename}';
+}
+
+class _FileContentFutureReference extends FutureReference<String> {
+  final File file;
+
+  _FileContentFutureReference(
+      MutableRecording recording, String name, Future<String> future)
+      : file = recording.newFile(name),
+        super(future);
+
+  @override
+  Future<String> get value => super.value.then((String content) async {
+        await file.writeAsString(content, flush: true);
+        return content;
+      });
+
+  @override
+  dynamic get serializedValue => '!${file.basename}';
+}
+
+class _FileContentReference extends ResultReference<String> {
+  final File file;
+  final String content;
+
+  _FileContentReference(MutableRecording recording, String name, this.content)
+      : file = recording.newFile(name);
+
+  @override
+  String get value {
+    file.writeAsStringSync(content, flush: true);
+    return content;
+  }
+
+  @override
+  String get recordedValue => content;
+
+  @override
+  dynamic get serializedValue => '!${file.basename}';
+}
+
+class _LinesFutureReference extends FutureReference<List<String>> {
+  final File file;
+
+  _LinesFutureReference(
+      MutableRecording recording, String name, Future<List<String>> future)
+      : file = recording.newFile(name),
+        super(future);
+
+  @override
+  Future<List<String>> get value =>
+      super.value.then((List<String> lines) async {
+        await file.writeAsString(lines.join('\n'), flush: true);
+        return lines;
+      });
+
+  @override
+  dynamic get serializedValue => '!${file.basename}';
+}
+
+class _LinesReference extends ResultReference<List<String>> {
+  final File file;
+  final List<String> lines;
+
+  _LinesReference(MutableRecording recording, String name, this.lines)
+      : file = recording.newFile(name);
+
+  @override
+  List<String> get value {
+    file.writeAsStringSync(lines.join('\n'), flush: true);
+    return lines;
+  }
+
+  @override
+  List<String> get recordedValue => lines;
+
+  @override
+  dynamic get serializedValue => '!${file.basename}';
 }

--- a/lib/src/backends/record_replay/result_reference.dart
+++ b/lib/src/backends/record_replay/result_reference.dart
@@ -89,8 +89,9 @@ class FutureReference<T> extends ResultReference<Future<T>> {
   @override
   T get recordedValue => _value;
 
+  // TODO(tvolkert): remove `.then()` once Dart 1.22 is in stable
   @override
-  Future<Null> get complete => value;
+  Future<Null> get complete => value.then<Null>((_) {});
 }
 
 /// Wraps a stream result.

--- a/lib/src/backends/record_replay/result_reference.dart
+++ b/lib/src/backends/record_replay/result_reference.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
+
 import 'encoding.dart';
 import 'events.dart';
 import 'recording_proxy_mixin.dart';
@@ -128,6 +130,7 @@ class StreamReference<T> extends ResultReference<Stream<T>> {
     return _stream.listen(
       (T element) {
         _data.add(element);
+        onData(element);
         _controller.add(element);
       },
       onError: (dynamic error, StackTrace stackTrace) {
@@ -135,11 +138,26 @@ class StreamReference<T> extends ResultReference<Stream<T>> {
         _controller.addError(error, stackTrace);
       },
       onDone: () {
+        onDone();
         _completer.complete();
         _controller.close();
       },
     );
   }
+
+  /// Called when an event is received from the underlying delegate stream.
+  ///
+  /// Subclasses may override this method to be notified when events are
+  /// fired from the underlying stream.
+  @protected
+  void onData(T event) {}
+
+  /// Called when the underlying delegate stream fires a "done" event.
+  ///
+  /// Subclasses may override this method to be notified when the underlying
+  /// stream is done.
+  @protected
+  void onDone() {}
 
   @override
   Stream<T> get value => _controller.stream;

--- a/lib/src/testing/core_matchers.dart
+++ b/lib/src/testing/core_matchers.dart
@@ -57,6 +57,10 @@ void expectFileSystemException(dynamic message, void callback()) {
   expect(callback, throwsFileSystemException(message));
 }
 
+/// Matcher that successfully matches against a [FileSystemEntity] that
+/// exists ([FileSystemEntity.existsSync] returns true).
+const Matcher exists = const _Exists();
+
 class _FileSystemException extends Matcher {
   final Matcher _matcher;
 
@@ -107,5 +111,27 @@ class _HasPath extends Matcher {
     _matcher.describeMismatch(item.path, pathDesc, matchState, verbose);
     desc.add(pathDesc.toString());
     return desc;
+  }
+}
+
+class _Exists extends Matcher {
+  const _Exists();
+
+  @override
+  bool matches(dynamic item, Map<dynamic, dynamic> matchState) =>
+      item is FileSystemEntity && item.existsSync();
+
+  @override
+  Description describe(Description description) =>
+      description.add('a file system entity that exists');
+
+  @override
+  Description describeMismatch(
+    dynamic item,
+    Description description,
+    Map<dynamic, dynamic> matchState,
+    bool verbose,
+  ) {
+    return description.add('does not exist');
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ description: A pluggable, mockable file system abstraction for Dart.
 homepage: https://github.com/matanlurey/file
 
 dependencies:
+  intl: ^0.14.0
   meta: ^1.0.4
   path: ^1.4.0
 

--- a/test/recording_test.dart
+++ b/test/recording_test.dart
@@ -9,6 +9,7 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:file/record_replay.dart';
 import 'package:file/testing.dart';
+import 'package:file/src/backends/record_replay/common.dart';
 import 'package:file/src/backends/record_replay/mutable_recording.dart';
 import 'package:file/src/backends/record_replay/recording_proxy_mixin.dart';
 import 'package:path/path.dart' as p;
@@ -18,15 +19,15 @@ import 'common_tests.dart';
 
 void main() {
   group('SupportingClasses', () {
-    BasicClass delegate;
-    RecordingClass rc;
+    _BasicClass delegate;
+    _RecordingClass rc;
     MutableRecording recording;
 
     setUp(() {
-      delegate = new BasicClass();
-      rc = new RecordingClass(
+      delegate = new _BasicClass();
+      rc = new _RecordingClass(
         delegate: delegate,
-        stopwatch: new FakeStopwatch(10),
+        stopwatch: new _FakeStopwatch(10),
         destination: new MemoryFileSystem().directory('/tmp')..createSync(),
       );
       recording = rc.recording;
@@ -114,34 +115,25 @@ void main() {
 
     group('MutableRecording', () {
       group('flush', () {
-        List<Map<String, dynamic>> loadManifestFromFileSystem() {
-          List<FileSystemEntity> files = recording.destination.listSync();
-          expect(files.length, 1);
-          expect(files[0], isFile);
-          expect(files[0].basename, 'MANIFEST.txt');
-          File manifestFile = files[0];
-          return new JsonDecoder().convert(manifestFile.readAsStringSync());
-        }
-
         test('writesManifestToFileSystemAsJson', () async {
           rc.basicProperty = 'foo';
           String value = rc.basicProperty;
           rc.basicMethod(value, namedArg: 'bar');
           await recording.flush();
-          List<Map<String, dynamic>> manifest = loadManifestFromFileSystem();
+          List<Map<String, dynamic>> manifest = _loadManifest(recording);
           expect(manifest, hasLength(3));
           expect(manifest[0], <String, dynamic>{
             'type': 'set',
             'property': 'basicProperty=',
             'value': 'foo',
-            'object': 'RecordingClass',
+            'object': '_RecordingClass',
             'result': null,
             'timestamp': 10,
           });
           expect(manifest[1], <String, dynamic>{
             'type': 'get',
             'property': 'basicProperty',
-            'object': 'RecordingClass',
+            'object': '_RecordingClass',
             'result': 'foo',
             'timestamp': 11,
           });
@@ -150,7 +142,7 @@ void main() {
             'method': 'basicMethod',
             'positionalArguments': <String>['foo'],
             'namedArguments': <String, dynamic>{'namedArg': 'bar'},
-            'object': 'RecordingClass',
+            'object': '_RecordingClass',
             'result': 'foo.bar',
             'timestamp': 12
           });
@@ -159,7 +151,7 @@ void main() {
         test('doesntAwaitPendingResultsUnlessToldToDoSo', () async {
           rc.futureMethod('foo', namedArg: 'bar'); // ignore: unawaited_futures
           await recording.flush();
-          List<Map<String, dynamic>> manifest = loadManifestFromFileSystem();
+          List<Map<String, dynamic>> manifest = _loadManifest(recording);
           expect(manifest[0], containsPair('result', null));
         });
 
@@ -167,7 +159,7 @@ void main() {
           rc.futureMethod('foo', namedArg: 'bar'); // ignore: unawaited_futures
           await recording.flush(
               awaitPendingResults: const Duration(seconds: 30));
-          List<Map<String, dynamic>> manifest = loadManifestFromFileSystem();
+          List<Map<String, dynamic>> manifest = _loadManifest(recording);
           expect(manifest[0], containsPair('result', 'future.foo.bar'));
         });
 
@@ -178,7 +170,7 @@ void main() {
               awaitPendingResults: const Duration(milliseconds: 250));
           DateTime after = new DateTime.now();
           Duration delta = after.difference(before);
-          List<Map<String, dynamic>> manifest = loadManifestFromFileSystem();
+          List<Map<String, dynamic>> manifest = _loadManifest(recording);
           expect(manifest[0], containsPair('result', isNull));
           expect(delta.inMilliseconds, greaterThanOrEqualTo(250));
         });
@@ -448,46 +440,301 @@ void main() {
         });
       });
 
-      group('File', () {});
+      group('File', () {
+        test('create', () {});
+
+        test('createSync', () {});
+
+        test('rename', () {});
+
+        test('renameSync', () {});
+
+        test('copy', () {});
+
+        test('copySync', () {});
+
+        test('length', () {});
+
+        test('lengthSync', () {});
+
+        test('absolute', () {});
+
+        test('lastModified', () {});
+
+        test('lastModifiedSync', () {});
+
+        test('open', () {});
+
+        test('openSync', () {});
+
+        test('openRead', () async {
+          String content = 'Hello\nWorld';
+          await delegate.file('/foo').writeAsString(content, flush: true);
+          Stream<List<int>> stream = fs.file('/foo').openRead();
+          await stream.drain();
+          expect(
+              recording.events,
+              contains(invokesMethod('openRead')
+                  .on(isFile)
+                  .withPositionalArguments(isEmpty)
+                  .withNoNamedArguments()
+                  .withResult(isList)));
+          await recording.flush();
+          List<Map<String, dynamic>> manifest = _loadManifest(recording);
+          expect(manifest, hasLength(2));
+          expect(
+              manifest[1],
+              allOf(
+                containsPair('type', 'invoke'),
+                containsPair('method', 'openRead'),
+                containsPair('object', matches(r'^RecordingFile@[0-9]+$')),
+                containsPair('positionalArguments', isEmpty),
+                containsPair('namedArguments', isEmpty),
+                containsPair('result', matches(r'^![0-9]+.openRead$')),
+              ));
+          File file = _getRecordingFile(recording, manifest[1]['result']);
+          expect(file, exists);
+          expect(await file.readAsString(), content);
+        });
+
+        test('openWrite', () {});
+
+        test('readAsBytes', () async {
+          String content = 'Hello\nWorld';
+          await delegate.file('/foo').writeAsString(content, flush: true);
+          await fs.file('/foo').readAsBytes();
+          expect(
+              recording.events,
+              contains(invokesMethod('readAsBytes')
+                  .on(isFile)
+                  .withNoNamedArguments()
+                  .withResult(allOf(isList, hasLength(content.length)))));
+          await recording.flush();
+          List<Map<String, dynamic>> manifest = _loadManifest(recording);
+          expect(manifest, hasLength(2));
+          expect(
+              manifest[1],
+              allOf(
+                containsPair('type', 'invoke'),
+                containsPair('method', 'readAsBytes'),
+                containsPair('object', matches(r'^RecordingFile@[0-9]+$')),
+                containsPair('positionalArguments', isEmpty),
+                containsPair('namedArguments', isEmpty),
+                containsPair('result', matches(r'^![0-9]+.readAsBytes$')),
+              ));
+          File file = _getRecordingFile(recording, manifest[1]['result']);
+          expect(file, exists);
+          expect(await file.readAsString(), content);
+        });
+
+        test('readAsBytesSync', () async {
+          String content = 'Hello\nWorld';
+          await delegate.file('/foo').writeAsString(content, flush: true);
+          fs.file('/foo').readAsBytesSync();
+          expect(
+              recording.events,
+              contains(invokesMethod('readAsBytesSync')
+                  .on(isFile)
+                  .withNoNamedArguments()
+                  .withResult(allOf(isList, hasLength(content.length)))));
+          await recording.flush();
+          List<Map<String, dynamic>> manifest = _loadManifest(recording);
+          expect(manifest, hasLength(2));
+          expect(
+              manifest[1],
+              allOf(
+                containsPair('type', 'invoke'),
+                containsPair('method', 'readAsBytesSync'),
+                containsPair('object', matches(r'^RecordingFile@[0-9]+$')),
+                containsPair('positionalArguments', isEmpty),
+                containsPair('namedArguments', isEmpty),
+                containsPair('result', matches(r'^![0-9]+.readAsBytesSync$')),
+              ));
+          File file = _getRecordingFile(recording, manifest[1]['result']);
+          expect(file, exists);
+          expect(await file.readAsString(), content);
+        });
+
+        test('readAsString', () async {
+          String content = 'Hello\nWorld';
+          await delegate
+              .file('/foo')
+              .writeAsString(content, encoding: LATIN1, flush: true);
+          await fs.file('/foo').readAsString(encoding: LATIN1);
+          expect(
+              recording.events,
+              contains(invokesMethod('readAsString')
+                  .on(isFile)
+                  .withNamedArgument('encoding', LATIN1)
+                  .withResult(content)));
+          await recording.flush();
+          List<Map<String, dynamic>> manifest = _loadManifest(recording);
+          expect(manifest, hasLength(2));
+          expect(
+              manifest[1],
+              allOf(
+                containsPair('type', 'invoke'),
+                containsPair('method', 'readAsString'),
+                containsPair('object', matches(r'^RecordingFile@[0-9]+$')),
+                containsPair('positionalArguments', isEmpty),
+                containsPair('result', matches(r'^![0-9]+.readAsString$')),
+                containsPair(
+                    'namedArguments',
+                    allOf(
+                      hasLength(1),
+                      containsPair('encoding', 'iso-8859-1'),
+                    )),
+              ));
+          File file = _getRecordingFile(recording, manifest[1]['result']);
+          expect(file, exists);
+          expect(await file.readAsString(), content);
+        });
+
+        test('readAsStringSync', () async {
+          String content = 'Hello\nWorld';
+          await delegate
+              .file('/foo')
+              .writeAsString(content, encoding: LATIN1, flush: true);
+          fs.file('/foo').readAsStringSync(encoding: LATIN1);
+          expect(
+              recording.events,
+              contains(invokesMethod('readAsStringSync')
+                  .on(isFile)
+                  .withNamedArgument('encoding', LATIN1)
+                  .withResult(content)));
+          await recording.flush();
+          List<Map<String, dynamic>> manifest = _loadManifest(recording);
+          expect(manifest, hasLength(2));
+          expect(
+              manifest[1],
+              allOf(
+                containsPair('type', 'invoke'),
+                containsPair('method', 'readAsStringSync'),
+                containsPair('object', matches(r'^RecordingFile@[0-9]+$')),
+                containsPair('positionalArguments', isEmpty),
+                containsPair('result', matches(r'^![0-9]+.readAsStringSync$')),
+                containsPair(
+                    'namedArguments',
+                    allOf(
+                      hasLength(1),
+                      containsPair('encoding', 'iso-8859-1'),
+                    )),
+              ));
+          File file = _getRecordingFile(recording, manifest[1]['result']);
+          expect(file, exists);
+          expect(await file.readAsString(), content);
+        });
+
+        test('readAsLines', () async {
+          String content = 'Hello\nWorld';
+          await delegate.file('/foo').writeAsString(content, flush: true);
+          await fs.file('/foo').readAsLines();
+          expect(
+              recording.events,
+              contains(invokesMethod('readAsLines')
+                  .on(isFile)
+                  .withNoNamedArguments()
+                  .withResult(<String>['Hello', 'World'])));
+          await recording.flush();
+          List<Map<String, dynamic>> manifest = _loadManifest(recording);
+          expect(manifest, hasLength(2));
+          expect(
+              manifest[1],
+              allOf(
+                containsPair('type', 'invoke'),
+                containsPair('method', 'readAsLines'),
+                containsPair('object', matches(r'^RecordingFile@[0-9]+$')),
+                containsPair('positionalArguments', isEmpty),
+                containsPair('result', matches(r'^![0-9]+.readAsLines$')),
+                containsPair('namedArguments', isEmpty),
+              ));
+          File file = _getRecordingFile(recording, manifest[1]['result']);
+          expect(file, exists);
+          expect(await file.readAsString(), content);
+        });
+
+        test('readAsLinesSync', () async {
+          String content = 'Hello\nWorld';
+          await delegate.file('/foo').writeAsString(content, flush: true);
+          fs.file('/foo').readAsLinesSync();
+          expect(
+              recording.events,
+              contains(invokesMethod('readAsLinesSync')
+                  .on(isFile)
+                  .withNoNamedArguments()
+                  .withResult(<String>['Hello', 'World'])));
+          await recording.flush();
+          List<Map<String, dynamic>> manifest = _loadManifest(recording);
+          expect(manifest, hasLength(2));
+          expect(
+              manifest[1],
+              allOf(
+                containsPair('type', 'invoke'),
+                containsPair('method', 'readAsLinesSync'),
+                containsPair('object', matches(r'^RecordingFile@[0-9]+$')),
+                containsPair('positionalArguments', isEmpty),
+                containsPair('result', matches(r'^![0-9]+.readAsLinesSync$')),
+                containsPair('namedArguments', isEmpty),
+              ));
+          File file = _getRecordingFile(recording, manifest[1]['result']);
+          expect(file, exists);
+          expect(await file.readAsString(), content);
+        });
+
+        test('writeAsBytes', () {});
+
+        test('writeAsBytesSync', () {});
+
+        test('writeAsString', () {});
+
+        test('writeAsStringSync', () {});
+      });
 
       group('Link', () {});
     });
   });
 }
 
-// ignore: public_member_api_docs
-class BasicClass {
-  // ignore: public_member_api_docs
+List<Map<String, dynamic>> _loadManifest(LiveRecording recording) {
+  List<FileSystemEntity> files = recording.destination.listSync();
+  File manifestFile = files.singleWhere(
+      (FileSystemEntity entity) => entity.basename == kManifestName);
+  return new JsonDecoder().convert(manifestFile.readAsStringSync());
+}
+
+File _getRecordingFile(LiveRecording recording, String manifestReference) {
+  expect(manifestReference, startsWith('!'));
+  String basename = manifestReference.substring(1);
+  String dirname = recording.destination.path;
+  String path = recording.destination.fileSystem.path.join(dirname, basename);
+  return recording.destination.fileSystem.file(path);
+}
+
+class _BasicClass {
   String basicProperty;
 
-  // ignore: public_member_api_docs
   Future<String> get futureProperty async => 'future.$basicProperty';
 
-  // ignore: public_member_api_docs
   String basicMethod(String positionalArg, {String namedArg}) =>
       '$positionalArg.$namedArg';
 
-  // ignore: public_member_api_docs
   Future<String> futureMethod(String positionalArg, {String namedArg}) async {
     await new Future<Null>.delayed(const Duration(milliseconds: 500));
     String basicValue = basicMethod(positionalArg, namedArg: namedArg);
     return 'future.$basicValue';
   }
 
-  // ignore: public_member_api_docs
   Stream<String> streamMethod(String positionalArg, {String namedArg}) async* {
     yield 'stream';
     yield positionalArg;
     yield namedArg;
   }
 
-  // ignore: public_member_api_docs
   Future<String> veryLongFutureMethod() async {
     await new Future<Null>.delayed(const Duration(seconds: 1));
     return 'future';
   }
 
-  // ignore: public_member_api_docs
   Stream<String> infiniteStreamMethod() async* {
     yield 'stream';
     int i = 0;
@@ -498,15 +745,12 @@ class BasicClass {
   }
 }
 
-// ignore: public_member_api_docs
-class RecordingClass extends Object
+class _RecordingClass extends Object
     with RecordingProxyMixin
-    implements BasicClass {
-  // ignore: public_member_api_docs
-  final BasicClass delegate;
+    implements _BasicClass {
+  final _BasicClass delegate;
 
-  // ignore: public_member_api_docs
-  RecordingClass({
+  _RecordingClass({
     this.delegate,
     this.stopwatch,
     Directory destination,
@@ -536,12 +780,10 @@ class RecordingClass extends Object
   final Stopwatch stopwatch;
 }
 
-// ignore: public_member_api_docs
-class FakeStopwatch implements Stopwatch {
+class _FakeStopwatch implements Stopwatch {
   int _value;
 
-  // ignore: public_member_api_docs
-  FakeStopwatch(this._value);
+  _FakeStopwatch(this._value);
 
   @override
   int get elapsedMilliseconds => _value++;

--- a/test/recording_test.dart
+++ b/test/recording_test.dart
@@ -441,6 +441,7 @@ void main() {
       });
 
       group('File', () {
+        // TODO(tvolkert): Fill in these test stubs
         test('create', () {});
 
         test('createSync', () {});


### PR DESCRIPTION
This uses the work that was done in #18 to wire up special
handling of certain file operations such that their results
will be written out to dedicated recording files.

(more work towards #11)