### PR TITLE
Deeply encode objects in `encode()`

### DIFF
--- a/lib/src/backends/record_replay/events.dart
+++ b/lib/src/backends/record_replay/events.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'common.dart';
+import 'encoding.dart';
 import 'recording.dart';
 import 'result_reference.dart';
 
@@ -101,11 +103,13 @@ abstract class LiveInvocationEvent<T> implements InvocationEvent<T> {
   }
 
   /// Returns this event as a JSON-serializable object.
-  Map<String, dynamic> serialize() => <String, dynamic>{
-        'object': object,
-        'result': _result,
-        'timestamp': timestamp,
-      };
+  Future<Map<String, dynamic>> serialize() async {
+    return <String, dynamic>{
+      'object': await encode(object),
+      'result': await encode(_result),
+      'timestamp': timestamp,
+    };
+  }
 
   @override
   String toString() => serialize().toString();
@@ -122,10 +126,12 @@ class LivePropertyGetEvent<T> extends LiveInvocationEvent<T>
   final Symbol property;
 
   @override
-  Map<String, dynamic> serialize() => <String, dynamic>{
-        'type': 'get',
-        'property': property,
-      }..addAll(super.serialize());
+  Future<Map<String, dynamic>> serialize() async {
+    return <String, dynamic>{
+      'type': 'get',
+      'property': getSymbolName(property),
+    }..addAll(await super.serialize());
+  }
 }
 
 /// A [PropertySetEvent] that's in the process of being recorded.
@@ -142,11 +148,13 @@ class LivePropertySetEvent<T> extends LiveInvocationEvent<Null>
   final T value;
 
   @override
-  Map<String, dynamic> serialize() => <String, dynamic>{
-        'type': 'set',
-        'property': property,
-        'value': value,
-      }..addAll(super.serialize());
+  Future<Map<String, dynamic>> serialize() async {
+    return <String, dynamic>{
+      'type': 'set',
+      'property': getSymbolName(property),
+      'value': await encode(value),
+    }..addAll(await super.serialize());
+  }
 }
 
 /// A [MethodEvent] that's in the process of being recorded.
@@ -177,10 +185,12 @@ class LiveMethodEvent<T> extends LiveInvocationEvent<T>
   final Map<Symbol, dynamic> namedArguments;
 
   @override
-  Map<String, dynamic> serialize() => <String, dynamic>{
-        'type': 'invoke',
-        'method': method,
-        'positionalArguments': positionalArguments,
-        'namedArguments': namedArguments,
-      }..addAll(super.serialize());
+  Future<Map<String, dynamic>> serialize() async {
+    return <String, dynamic>{
+      'type': 'invoke',
+      'method': getSymbolName(method),
+      'positionalArguments': await encodeIterable(positionalArguments),
+      'namedArguments': await encodeMap(namedArguments),
+    }..addAll(await super.serialize());
+  }
 }

--- a/lib/src/backends/record_replay/mutable_recording.dart
+++ b/lib/src/backends/record_replay/mutable_recording.dart
@@ -46,7 +46,8 @@ class MutableRecording implements LiveRecording {
             .timeout(awaitPendingResults, onTimeout: () {});
       }
       Directory dir = destination;
-      String json = new JsonEncoder.withIndent('  ', encode).convert(_events);
+      List<dynamic> encodedEvents = await encode(_events);
+      String json = new JsonEncoder.withIndent('  ').convert(encodedEvents);
       String filename = dir.fileSystem.path.join(dir.path, kManifestName);
       await dir.fileSystem.file(filename).writeAsString(json, flush: true);
     } finally {

--- a/lib/src/backends/record_replay/result_reference.dart
+++ b/lib/src/backends/record_replay/result_reference.dart
@@ -49,7 +49,7 @@ abstract class ResultReference<T> {
   /// actually a byte array that was read from a file). In this case, the
   /// method can return a `ResultReference` to the list, and it will have a
   /// hook into the serialization process.
-  dynamic get serializedValue => encode(recordedValue);
+  Future<dynamic> get serializedValue => encode(recordedValue);
 
   /// A [Future] that completes when [value] has completed.
   ///


### PR DESCRIPTION
This changes `encode()` to deeply encode the specified object
rather than performing a shallow encode. Previously, it relied
on `JSONEncoder` to do the work of walking the object graph and
calling `toEncodable` whenever it found a non-JSON type. Now,
callers can call `encode()` on the top-level object and get back
a deeply JSON-typed object that can be converted to JSON without
the need for a `toEncodable` callback.

This will be used during replay, when we'll compare an invocation
to the list of recorded invocations, each of which exists as a
JSON-type map.

Since we now control the encoding process entirely ourselves,
this also changes `encode()` to return `Future<dynamic>` rather than
`dynamic`, which in turn allows both `InvocationEvent.serialize()` and
`ResultReference.serializedValue` to return futures as well.
Doing so allows for more technical correctness when serializing
result references.

Part of #11