### PR TITLE
Partial implementation of ReplayFileSystem

### DIFF
--- a/lib/record_replay.dart
+++ b/lib/record_replay.dart
@@ -2,8 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+export 'src/backends/record_replay/errors.dart';
 export 'src/backends/record_replay/events.dart'
     show InvocationEvent, PropertyGetEvent, PropertySetEvent, MethodEvent;
 export 'src/backends/record_replay/recording.dart';
 export 'src/backends/record_replay/recording_file_system.dart'
     show RecordingFileSystem;
+export 'src/backends/record_replay/replay_file_system.dart'
+    show ReplayFileSystem;

--- a/lib/src/backends/record_replay/common.dart
+++ b/lib/src/backends/record_replay/common.dart
@@ -51,9 +51,9 @@ const String kManifestPositionalArgumentsKey = 'positionalArguments';
 /// named arguments that were passed to the method.
 const String kManifestNamedArgumentsKey = 'namedArguments';
 
-/// The key in a serialized [InvocationEvent] map that is used to store whether
-/// the invocation has been replayed already.
-const String kManifestReplayedKey = 'replayed';
+/// The key in a serialized [InvocationEvent] map that is used to store the
+/// order in which the invocation has been replayed (if it has been replayed).
+const String kManifestOrdinalKey = 'ordinal';
 
 /// The serialized [kManifestTypeKey] for property retrievals.
 const String kGetType = 'get';

--- a/lib/src/backends/record_replay/encoding.dart
+++ b/lib/src/backends/record_replay/encoding.dart
@@ -15,6 +15,7 @@ import 'recording_file_system_entity.dart';
 import 'recording_io_sink.dart';
 import 'recording_link.dart';
 import 'recording_random_access_file.dart';
+import 'replay_proxy_mixin.dart';
 import 'result_reference.dart';
 
 /// Encodes an object into a JSON-ready representation.
@@ -48,6 +49,7 @@ const Map<TypeMatcher<dynamic>, _Encoder> _kEncoders =
   const TypeMatcher<RecordingLink>(): _encodeFileSystemEntity,
   const TypeMatcher<RecordingIOSink>(): _encodeIOSink,
   const TypeMatcher<RecordingRandomAccessFile>(): _encodeRandomAccessFile,
+  const TypeMatcher<ReplayProxyMixin>(): _encodeReplayEntity,
   const TypeMatcher<Encoding>(): _encodeEncoding,
   const TypeMatcher<FileMode>(): _encodeFileMode,
   const TypeMatcher<FileStat>(): _encodeFileStat,
@@ -131,6 +133,8 @@ String _encodeIOSink(RecordingIOSink sink) {
 String _encodeRandomAccessFile(RecordingRandomAccessFile raf) {
   return '${raf.runtimeType}@${raf.uid}';
 }
+
+String _encodeReplayEntity(ReplayProxyMixin entity) => entity.identifier;
 
 String _encodeEncoding(Encoding encoding) => encoding.name;
 

--- a/lib/src/backends/record_replay/errors.dart
+++ b/lib/src/backends/record_replay/errors.dart
@@ -33,10 +33,7 @@ class NoMatchingInvocationError extends Error {
         if (i++ > 0) {
           buf.write(', ');
         }
-        buf
-          ..write(getSymbolName(name))
-          ..write(': ')
-          ..write(encode(value));
+        buf.write('${getSymbolName(name)}: ${encode(value)}');
       });
       buf.write(')');
     } else if (invocation.isSetter) {

--- a/lib/src/backends/record_replay/errors.dart
+++ b/lib/src/backends/record_replay/errors.dart
@@ -11,8 +11,8 @@ class NoMatchingInvocationError extends Error {
   /// The invocation that was unable to be replayed.
   final Invocation invocation;
 
-  /// Creates a new `InvocationError` caused by the failure to replay the
-  /// specified [invocation].
+  /// Creates a new `NoMatchingInvocationError` caused by the failure to replay
+  /// the specified [invocation].
   NoMatchingInvocationError(this.invocation);
 
   @override
@@ -30,8 +30,10 @@ class NoMatchingInvocationError extends Error {
         }
       }
       invocation.namedArguments.forEach((Symbol name, dynamic value) {
+        if (i++ > 0) {
+          buf.write(', ');
+        }
         buf
-          ..write(', ')
           ..write(getSymbolName(name))
           ..write(': ')
           ..write(encode(value));

--- a/lib/src/backends/record_replay/errors.dart
+++ b/lib/src/backends/record_replay/errors.dart
@@ -24,7 +24,7 @@ class NoMatchingInvocationError extends Error {
       buf.write('(');
       int i = 0;
       for (dynamic arg in invocation.positionalArguments) {
-        buf.write(Error.safeToString(arg));
+        buf.write(Error.safeToString(encode(arg)));
         if (i++ > 0) {
           buf.write(', ');
         }
@@ -37,6 +37,8 @@ class NoMatchingInvocationError extends Error {
           ..write(encode(value));
       });
       buf.write(')');
+    } else if (invocation.isSetter) {
+      buf.write(Error.safeToString(encode(invocation.positionalArguments[0])));
     }
     return buf.toString();
   }

--- a/lib/src/backends/record_replay/errors.dart
+++ b/lib/src/backends/record_replay/errors.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'common.dart';
+import 'encoding.dart';
+
+/// Error thrown during replay when there is no matching invocation in the
+/// recording.
+class NoMatchingInvocationError extends Error {
+  /// The invocation that was unable to be replayed.
+  final Invocation invocation;
+
+  /// Creates a new `InvocationError` caused by the failure to replay the
+  /// specified [invocation].
+  NoMatchingInvocationError(this.invocation);
+
+  @override
+  String toString() {
+    StringBuffer buf = new StringBuffer();
+    buf.write('No matching invocation found: ');
+    buf.write(getSymbolName(invocation.memberName));
+    if (invocation.isMethod) {
+      buf.write('(');
+      int i = 0;
+      for (dynamic arg in invocation.positionalArguments) {
+        buf.write(Error.safeToString(arg));
+        if (i++ > 0) {
+          buf.write(', ');
+        }
+      }
+      invocation.namedArguments.forEach((Symbol name, dynamic value) {
+        buf
+          ..write(', ')
+          ..write(getSymbolName(name))
+          ..write(': ')
+          ..write(encode(value));
+      });
+      buf.write(')');
+    }
+    return buf.toString();
+  }
+}

--- a/lib/src/backends/record_replay/proxy.dart
+++ b/lib/src/backends/record_replay/proxy.dart
@@ -15,16 +15,14 @@ abstract class ProxyObject {}
 class MethodProxy extends Object implements Function {
   /// The object on which the method was retrieved.
   ///
-  /// This will be the target object when this proxy is invoked.
+  /// This will be the target object when this method proxy is invoked.
   final ProxyObject _proxyObject;
 
-  /// The name of the method that was retrieved.
-  ///
-  /// This method will be invoked when this proxy is invoked.
+  /// The name of the method in question.
   final Symbol _methodName;
 
   /// Creates a new [MethodProxy] that, when invoked, will invoke the method
-  /// identified by [methodName] on the specified target proxy [object].
+  /// identified by [methodName] on the specified target [object].
   MethodProxy(ProxyObject object, Symbol methodName)
       : _proxyObject = object,
         _methodName = methodName;

--- a/lib/src/backends/record_replay/proxy.dart
+++ b/lib/src/backends/record_replay/proxy.dart
@@ -1,0 +1,68 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// An object that uses [noSuchMethod] to dynamically handle invocations
+/// (property getters, property setters, and method invocations).
+abstract class ProxyObject {}
+
+/// A function reference that, when invoked, will forward the invocation back
+/// to a [ProxyObject].
+///
+/// This is used when a caller accesses a method on a [ProxyObject] via the
+/// method's getter. In these cases, the caller will receive a [MethodProxy]
+/// that allows delayed invocation of the method.
+class MethodProxy extends Object implements Function {
+  /// The object on which the method was originally invoked.
+  final ProxyObject _proxyObject;
+
+  /// The name of the method that was originally invoked.
+  final Symbol _methodName;
+
+  /// Creates a new [MethodProxy] that, when invoked, will invoke the method
+  /// identified by [methodName] on the specified target proxy [object].
+  MethodProxy(ProxyObject object, Symbol methodName)
+      : _proxyObject = object,
+        _methodName = methodName;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.isMethod && invocation.memberName == #call) {
+      // The method is being invoked. Capture the arguments, and invoke the
+      // method on the object. We have to synthesize an invocation, since our
+      // current `invocation` object represents the invocation of `call()`.
+      return _proxyObject.noSuchMethod(new _MethodInvocationProxy(
+        _methodName,
+        invocation.positionalArguments,
+        invocation.namedArguments,
+      ));
+    }
+    return super.noSuchMethod(invocation);
+  }
+}
+
+class _MethodInvocationProxy extends Invocation {
+  _MethodInvocationProxy(
+    this.memberName,
+    this.positionalArguments,
+    this.namedArguments,
+  );
+
+  @override
+  final Symbol memberName;
+
+  @override
+  final List<dynamic> positionalArguments;
+
+  @override
+  final Map<Symbol, dynamic> namedArguments;
+
+  @override
+  final bool isMethod = true;
+
+  @override
+  final bool isGetter = false;
+
+  @override
+  final bool isSetter = false;
+}

--- a/lib/src/backends/record_replay/proxy.dart
+++ b/lib/src/backends/record_replay/proxy.dart
@@ -13,10 +13,14 @@ abstract class ProxyObject {}
 /// method's getter. In these cases, the caller will receive a [MethodProxy]
 /// that allows delayed invocation of the method.
 class MethodProxy extends Object implements Function {
-  /// The object on which the method was originally invoked.
+  /// The object on which the method was retrieved.
+  ///
+  /// This will be the target object when this proxy is invoked.
   final ProxyObject _proxyObject;
 
-  /// The name of the method that was originally invoked.
+  /// The name of the method that was retrieved.
+  ///
+  /// This method will be invoked when this proxy is invoked.
   final Symbol _methodName;
 
   /// Creates a new [MethodProxy] that, when invoked, will invoke the method
@@ -29,8 +33,8 @@ class MethodProxy extends Object implements Function {
   dynamic noSuchMethod(Invocation invocation) {
     if (invocation.isMethod && invocation.memberName == #call) {
       // The method is being invoked. Capture the arguments, and invoke the
-      // method on the object. We have to synthesize an invocation, since our
-      // current `invocation` object represents the invocation of `call()`.
+      // method on the proxy object. We have to synthesize an invocation, since
+      // our current `invocation` object represents the invocation of `call()`.
       return _proxyObject.noSuchMethod(new _MethodInvocationProxy(
         _methodName,
         invocation.positionalArguments,

--- a/lib/src/backends/record_replay/recording.dart
+++ b/lib/src/backends/record_replay/recording.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:file/file.dart';
 
 import 'events.dart';
+import 'replay_file_system.dart';
 
 /// A recording of a series of invocations on a [FileSystem] and its associated
 /// objects (`File`, `Directory`, `IOSink`, etc).
@@ -20,10 +21,9 @@ abstract class Recording {
 }
 
 /// An [Recording] in progress that can be serialized to disk for later use
-/// in `ReplayFileSystem`.
+/// in [ReplayFileSystem].
 ///
 /// Live recordings exist only in memory until [flush] is called.
-// TODO(tvolkert): Link to ReplayFileSystem in docs once it's implemented
 abstract class LiveRecording extends Recording {
   /// The directory in which recording files will be stored.
   ///

--- a/lib/src/backends/record_replay/recording_file_system.dart
+++ b/lib/src/backends/record_replay/recording_file_system.dart
@@ -11,12 +11,13 @@ import 'recording_directory.dart';
 import 'recording_file.dart';
 import 'recording_link.dart';
 import 'recording_proxy_mixin.dart';
+import 'replay_file_system.dart';
 
 /// File system that records invocations for later playback in tests.
 ///
 /// This will record all invocations (methods, property getters, and property
 /// setters) that occur on it, in an opaque format that can later be used in
-/// `ReplayFileSystem`. All activity in the [File], [Directory], [Link],
+/// [ReplayFileSystem]. All activity in the [File], [Directory], [Link],
 /// [IOSink], and [RandomAccessFile] instances returned from this API will also
 /// be recorded.
 ///
@@ -35,8 +36,7 @@ import 'recording_proxy_mixin.dart';
 ///     order.
 ///
 /// See also:
-///   - `ReplayFileSystem`
-// TODO(tvolkert): Link to ReplayFileSystem in docs once it's implemented
+///   - [ReplayFileSystem]
 abstract class RecordingFileSystem extends FileSystem {
   /// Creates a new `RecordingFileSystem`.
   ///

--- a/lib/src/backends/record_replay/replay_directory.dart
+++ b/lib/src/backends/record_replay/replay_directory.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:file/file.dart';
+
+import 'replay_file_system.dart';
+import 'replay_file_system_entity.dart';
+import 'resurrectors.dart';
+
+/// [Directory] implementation that replays all invocation activity from a
+/// prior recording.
+class ReplayDirectory extends ReplayFileSystemEntity<Directory>
+    implements Directory {
+  /// Creates a new `ReplayDirectory`.
+  ReplayDirectory(ReplayFileSystemImpl fileSystem, String identifier)
+      : super(fileSystem, identifier) {
+    // TODO(tvolkert): fill in resurrectors
+    methods.addAll(<Symbol, Resurrector>{
+      #create: null,
+      #createSync: null,
+      #createTemp: null,
+      #createTempSync: null,
+      #list: null,
+      #listSync: null,
+    });
+  }
+}

--- a/lib/src/backends/record_replay/replay_directory.dart
+++ b/lib/src/backends/record_replay/replay_directory.dart
@@ -10,8 +10,7 @@ import 'resurrectors.dart';
 
 /// [Directory] implementation that replays all invocation activity from a
 /// prior recording.
-class ReplayDirectory extends ReplayFileSystemEntity<Directory>
-    implements Directory {
+class ReplayDirectory extends ReplayFileSystemEntity implements Directory {
   /// Creates a new `ReplayDirectory`.
   ReplayDirectory(ReplayFileSystemImpl fileSystem, String identifier)
       : super(fileSystem, identifier) {

--- a/lib/src/backends/record_replay/replay_file.dart
+++ b/lib/src/backends/record_replay/replay_file.dart
@@ -10,7 +10,7 @@ import 'resurrectors.dart';
 
 /// [File] implementation that replays all invocation activity from a prior
 /// recording.
-class ReplayFile extends ReplayFileSystemEntity<File> implements File {
+class ReplayFile extends ReplayFileSystemEntity implements File {
   /// Creates a new `ReplayFile`.
   ReplayFile(ReplayFileSystemImpl fileSystem, String identifier)
       : super(fileSystem, identifier) {

--- a/lib/src/backends/record_replay/replay_file.dart
+++ b/lib/src/backends/record_replay/replay_file.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:file/file.dart';
+
+import 'replay_file_system.dart';
+import 'replay_file_system_entity.dart';
+import 'resurrectors.dart';
+
+/// [File] implementation that replays all invocation activity from a prior
+/// recording.
+class ReplayFile extends ReplayFileSystemEntity<File> implements File {
+  /// Creates a new `ReplayFile`.
+  ReplayFile(ReplayFileSystemImpl fileSystem, String identifier)
+      : super(fileSystem, identifier) {
+    // TODO(tvolkert): fill in resurrectors
+    methods.addAll(<Symbol, Resurrector>{
+      #create: null,
+      #createSync: null,
+      #copy: null,
+      #copySync: null,
+      #length: null,
+      #lengthSync: null,
+      #lastModified: null,
+      #lastModifiedSync: null,
+      #open: null,
+      #openSync: null,
+      #openRead: null,
+      #openWrite: null,
+      #readAsBytes: null,
+      #readAsBytesSync: null,
+      #readAsString: null,
+      #readAsStringSync: null,
+      #readAsLines: null,
+      #readAsLinesSync: null,
+      #writeAsBytes: null,
+      #writeAsBytesSync: null,
+      #writeAsString: null,
+      #writeAsStringSync: null,
+    });
+  }
+}

--- a/lib/src/backends/record_replay/replay_file_stat.dart
+++ b/lib/src/backends/record_replay/replay_file_stat.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:file/file.dart';
+
+import 'resurrectors.dart';
+
+/// [FileStat] implementation that derives its properties from a recorded
+/// invocation event.
+class ReplayFileStat implements FileStat {
+  final Map<String, dynamic> _data;
+
+  /// Creates a new `ReplayFileStat` that will derive its properties from the
+  /// specified [data].
+  ReplayFileStat(Map<String, dynamic> data) : _data = data;
+
+  @override
+  DateTime get changed => resurrectDateTime(_data['changed']);
+
+  @override
+  DateTime get modified => resurrectDateTime(_data['modified']);
+
+  @override
+  DateTime get accessed => resurrectDateTime(_data['accessed']);
+
+  @override
+  FileSystemEntityType get type => resurrectFileSystemEntityType(_data['type']);
+
+  @override
+  int get mode => _data['mode'];
+
+  @override
+  int get size => _data['size'];
+
+  @override
+  String modeString() => _data['modeString'];
+}

--- a/lib/src/backends/record_replay/replay_file_system.dart
+++ b/lib/src/backends/record_replay/replay_file_system.dart
@@ -1,0 +1,122 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:file/file.dart';
+import 'package:meta/meta.dart';
+
+import 'common.dart';
+import 'errors.dart';
+import 'recording_file_system.dart';
+import 'replay_directory.dart';
+import 'replay_file.dart';
+import 'replay_link.dart';
+import 'replay_proxy_mixin.dart';
+import 'resurrectors.dart';
+
+/// A file system that replays invocations from a prior recording for use
+/// in tests.
+///
+/// This will replay all invocations (methods, property getters, and property
+/// setters) that occur on it, based on an opaque recording that was generated
+/// in [RecordingFileSystem]. All activity in the [File], [Directory], [Link],
+/// [IOSink], and [RandomAccessFile] instances returned from this API will also
+/// be played form the same recording.
+///
+/// Once an invocation has been replayed once, it is marked as such and will
+/// not be eligible for further replay. If an eligible invocation cannot be
+/// found that matches an incoming invocation, a [NoMatchingInvocationError]
+/// will be thrown.
+///
+/// This class is intended for use in tests, where you would otherwise have to
+/// set up complex mocks or fake file systems. With this class, the process is
+/// as follows:
+///
+///   - You record the file system activity during a real run of your program
+///     by injecting a `RecordingFileSystem` that delegates to your real file
+///     system.
+///   - You serialize that recording to disk as your program finishes.
+///   - You use that recording in tests to create a mock file system that knows
+///     how to respond to the exact invocations your program makes. Any
+///     invocations that aren't in the recording will throw, and you can make
+///     assertions in your tests about which methods were invoked and in what
+///     order.
+///
+/// See also:
+///   - [RecordingFileSystem]
+abstract class ReplayFileSystem extends FileSystem {
+  /// Creates a new `ReplayFileSystem`.
+  ///
+  /// Recording data will be loaded from the specified [recording] location.
+  /// This location must have been created by [RecordingFileSystem], or an
+  /// [ArgumentError] will be thrown.
+  factory ReplayFileSystem({
+    @required Directory recording,
+  }) {
+    String dirname = recording.path;
+    String path = recording.fileSystem.path.join(dirname, kManifestName);
+    File manifestFile = recording.fileSystem.file(path);
+    if (!manifestFile.existsSync()) {
+      throw new ArgumentError('Not a valid recording directory: $dirname');
+    }
+    List<Map<String, dynamic>> manifest =
+        new JsonDecoder().convert(manifestFile.readAsStringSync());
+    return new ReplayFileSystemImpl(manifest);
+  }
+}
+
+/// Non-exported implementation class for `ReplayFileSystem`.
+class ReplayFileSystemImpl extends FileSystem
+    with ReplayProxyMixin
+    implements ReplayFileSystem {
+  final Map<String, Object> _objects = <String, Object>{};
+
+  /// Creates a new `ReplayFileSystemImpl`.
+  ReplayFileSystemImpl(this.manifest) {
+    methods.addAll(<Symbol, Resurrector>{
+      #directory: _resurrectDirectory,
+      #file: _resurrectFile,
+      #link: _resurrectLink,
+      #stat: resurrectFuture(resurrectFileStat),
+      #statSync: resurrectFileStat,
+      #identical: resurrectFuture(resurrectPassthrough),
+      #identicalSync: resurrectPassthrough,
+      #type: resurrectFuture(resurrectFileSystemEntityType),
+      #typeSync: resurrectFileSystemEntityType,
+    });
+
+    properties.addAll(<Symbol, Resurrector>{
+      #path: resurrectPathContext,
+      #systemTempDirectory: _resurrectDirectory,
+      #currentDirectory: _resurrectDirectory,
+      const Symbol('currentDirectory='): resurrectPassthrough,
+      #isWatchSupported: resurrectPassthrough,
+    });
+  }
+
+  @override
+  String get identifier => kFileSystemEncodedValue;
+
+  @override
+  final List<Map<String, dynamic>> manifest;
+
+  Object _resurrectDirectory(String identifier) {
+    return _objects.putIfAbsent(identifier, () {
+      return new ReplayDirectory(this, identifier);
+    });
+  }
+
+  Object _resurrectFile(String identifier) {
+    return _objects.putIfAbsent(identifier, () {
+      return new ReplayFile(this, identifier);
+    });
+  }
+
+  Object _resurrectLink(String identifier) {
+    return _objects.putIfAbsent(identifier, () {
+      return new ReplayLink(this, identifier);
+    });
+  }
+}

--- a/lib/src/backends/record_replay/replay_file_system.dart
+++ b/lib/src/backends/record_replay/replay_file_system.dart
@@ -20,7 +20,7 @@ import 'resurrectors.dart';
 /// setters) that occur on it, based on an opaque recording that was generated
 /// in [RecordingFileSystem]. All activity in the [File], [Directory], [Link],
 /// [IOSink], and [RandomAccessFile] instances returned from this API will also
-/// be replayed form the same recording.
+/// be replayed from the same recording.
 ///
 /// Once an invocation has been replayed once, it is marked as such and will
 /// not be eligible for further replay. If an eligible invocation cannot be

--- a/lib/src/backends/record_replay/replay_file_system_entity.dart
+++ b/lib/src/backends/record_replay/replay_file_system_entity.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:file/file.dart';
+
+import 'replay_file_system.dart';
+import 'replay_proxy_mixin.dart';
+import 'resurrectors.dart';
+
+/// [FileSystemEntity] implementation that replays all invocation activity
+/// from a prior recording.
+abstract class ReplayFileSystemEntity<T extends FileSystemEntity> extends Object
+    with ReplayProxyMixin
+    implements FileSystemEntity {
+  /// Creates a new `ReplayFileSystemEntity`.
+  ReplayFileSystemEntity(this.fileSystem, this.identifier) {
+    // TODO(tvolkert): fill in resurrectors
+    methods.addAll(<Symbol, Resurrector>{
+      #exists: null,
+      #existsSync: null,
+      #rename: null,
+      #renameSync: null,
+      #resolveSymbolicLinks: null,
+      #resolveSymbolicLinksSync: null,
+      #stat: null,
+      #statSync: null,
+      #delete: null,
+      #deleteSync: null,
+      #watch: null,
+    });
+
+    // TODO(tvolkert): fill in resurrectors
+    properties.addAll(<Symbol, Resurrector>{
+      #path: resurrectPassthrough,
+      #uri: null,
+      #isAbsolute: null,
+      #absolute: null,
+      #parent: null,
+      #basename: null,
+      #dirname: null,
+    });
+  }
+
+  @override
+  final ReplayFileSystemImpl fileSystem;
+
+  @override
+  final String identifier;
+
+  @override
+  List<Map<String, dynamic>> get manifest => fileSystem.manifest;
+}

--- a/lib/src/backends/record_replay/replay_file_system_entity.dart
+++ b/lib/src/backends/record_replay/replay_file_system_entity.dart
@@ -10,7 +10,7 @@ import 'resurrectors.dart';
 
 /// [FileSystemEntity] implementation that replays all invocation activity
 /// from a prior recording.
-abstract class ReplayFileSystemEntity<T extends FileSystemEntity> extends Object
+abstract class ReplayFileSystemEntity extends Object
     with ReplayProxyMixin
     implements FileSystemEntity {
   /// Creates a new `ReplayFileSystemEntity`.

--- a/lib/src/backends/record_replay/replay_link.dart
+++ b/lib/src/backends/record_replay/replay_link.dart
@@ -10,7 +10,7 @@ import 'resurrectors.dart';
 
 /// [Link] implementation that replays all invocation activity from a prior
 /// recording.
-class ReplayLink extends ReplayFileSystemEntity<Link> implements Link {
+class ReplayLink extends ReplayFileSystemEntity implements Link {
   /// Creates a new `ReplayLink`.
   ReplayLink(ReplayFileSystemImpl fileSystem, String identifier)
       : super(fileSystem, identifier) {

--- a/lib/src/backends/record_replay/replay_link.dart
+++ b/lib/src/backends/record_replay/replay_link.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:file/file.dart';
+
+import 'replay_file_system.dart';
+import 'replay_file_system_entity.dart';
+import 'resurrectors.dart';
+
+/// [Link] implementation that replays all invocation activity from a prior
+/// recording.
+class ReplayLink extends ReplayFileSystemEntity<Link> implements Link {
+  /// Creates a new `ReplayLink`.
+  ReplayLink(ReplayFileSystemImpl fileSystem, String identifier)
+      : super(fileSystem, identifier) {
+    // TODO(tvolkert): fill in resurrectors
+    methods.addAll(<Symbol, Resurrector>{
+      #create: null,
+      #createSync: null,
+      #update: null,
+      #updateSync: null,
+      #target: null,
+      #targetSync: null,
+    });
+  }
+}

--- a/lib/src/backends/record_replay/replay_proxy_mixin.dart
+++ b/lib/src/backends/record_replay/replay_proxy_mixin.dart
@@ -1,0 +1,135 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+
+import 'common.dart';
+import 'encoding.dart';
+import 'errors.dart';
+import 'proxy.dart';
+import 'resurrectors.dart';
+
+typedef bool _InvocationMatcher(Map<String, dynamic> entry);
+
+int _nextOrdinal = 0;
+
+/// Mixin that enables replaying of property accesses, property mutations, and
+/// method invocations from a prior recording.
+///
+/// This class uses `noSuchMethod` to replay a well-defined set of invocations
+/// (including property gets and sets) on an object. Subclasses wire this up by
+/// doing the following:
+///
+///   - Populate the list of method invocations to replay in the [methods] map.
+///   - Populate the list of property invocations to replay in the [properties]
+///     map. The symbol name for getters should be the property name, and the
+///     symbol name for setters should be the property name immediately
+///     followed by an equals sign (e.g. `propertyName=`).
+///   - Do not implement a concrete getter, setter, or method that you wish to
+///     replay, as doing so will circumvent the machinery that this mixin uses
+///     (`noSuchMethod`) to replay invocations.
+///
+/// **Example use**:
+///
+///     abstract class Foo {
+///       ComplexObject sampleMethod();
+///
+///       Foo sampleParent;
+///     }
+///
+///     class ReplayFoo extends Object with ReplayProxyMixin implements Foo {
+///       final String identifier;
+///       final List<Map<String, dynamic>> manifest;
+///
+///       ReplayFoo(this.manifest, this.identifier) {
+///         methods.addAll(<Symbol, Resurrector>{
+///           #sampleMethod: resurrectComplexobject,
+///         });
+///
+///         properties.addAll(<Symbol, Resurrector>{
+///           #sampleProperty: resurrectFoo,
+///           const Symbol('sampleProperty='): resurrectPassthrough,
+///         });
+///       }
+///     }
+abstract class ReplayProxyMixin implements ProxyObject {
+  /// TODO(tvolkert): document
+  @protected
+  final Map<Symbol, Resurrector> methods = <Symbol, Resurrector>{};
+
+  /// TODO(tvolkert): document
+  @protected
+  final Map<Symbol, Resurrector> properties = <Symbol, Resurrector>{};
+
+  /// TODO(tvolkert): document
+  String get identifier;
+
+  /// TODO(tvolkert): document
+  List<Map<String, dynamic>> get manifest;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    Symbol name = invocation.memberName;
+    Resurrector resurrector =
+        invocation.isAccessor ? properties[name] : methods[name];
+
+    if (resurrector == null) {
+      // No resurrector generally means that there truly is no such method on
+      // this object. The exception is when the invocation represents a getter
+      // on a method, in which case we return a method proxy that, when
+      // invoked, will replay the desired invocation.
+      return invocation.isGetter && methods[name] != null
+          ? new MethodProxy(this, name)
+          : super.noSuchMethod(invocation);
+    }
+
+    Map<String, dynamic> entry = _nextEvent(invocation);
+    if (entry == null) {
+      throw new NoMatchingInvocationError(invocation);
+    }
+    entry[kManifestOrdinalKey] = _nextOrdinal++;
+
+    assert(resurrector != null);
+    return resurrector(entry[kManifestResultKey]);
+  }
+
+  Map<String, dynamic> _nextEvent(Invocation invocation) {
+    _InvocationMatcher matches = _getMatcher(invocation);
+    return manifest.firstWhere((Map<String, dynamic> entry) {
+      return entry[kManifestOrdinalKey] == null && matches(entry);
+    }, orElse: () => null);
+  }
+
+  _InvocationMatcher _getMatcher(Invocation invocation) {
+    String name = getSymbolName(invocation.memberName);
+    List<dynamic> args = encode(invocation.positionalArguments);
+    Map<String, dynamic> namedArgs = encode(invocation.namedArguments);
+
+    if (invocation.isGetter) {
+      return (Map<String, dynamic> entry) =>
+          entry[kManifestTypeKey] == kGetType &&
+          entry[kManifestPropertyKey] == name &&
+          entry[kManifestObjectKey] == identifier;
+    } else if (invocation.isSetter) {
+      return (Map<String, dynamic> entry) =>
+          entry[kManifestTypeKey] == kSetType &&
+          entry[kManifestPropertyKey] == name &&
+          deeplyEqual(entry[kManifestValueKey], args[0]) &&
+          entry[kManifestObjectKey] == identifier;
+    } else {
+      return (Map<String, dynamic> entry) {
+        return entry[kManifestTypeKey] == kInvokeType &&
+            entry[kManifestMethodKey] == name &&
+            deeplyEqual(entry[kManifestPositionalArgumentsKey], args) &&
+            deeplyEqual(_asNamedArgsType(entry[kManifestNamedArgumentsKey]),
+                namedArgs) &&
+            entry[kManifestObjectKey] == identifier;
+      };
+    }
+  }
+
+  static Map<String, dynamic> _asNamedArgsType(Map<dynamic, dynamic> map) {
+    return new Map<String, dynamic>.from(map);
+  }
+}

--- a/lib/src/backends/record_replay/replay_proxy_mixin.dart
+++ b/lib/src/backends/record_replay/replay_proxy_mixin.dart
@@ -54,18 +54,37 @@ int _nextOrdinal = 0;
 ///       }
 ///     }
 abstract class ReplayProxyMixin implements ProxyObject {
-  /// TODO(tvolkert): document
+  /// Maps method names to [Resurrector] functions.
+  ///
+  /// Invocations of methods listed in this map will be replayed by looking for
+  /// matching invocations in the [manifest] and resurrecting the invocation
+  /// return value using the values in this map.
   @protected
   final Map<Symbol, Resurrector> methods = <Symbol, Resurrector>{};
 
-  /// TODO(tvolkert): document
+  /// Maps property getter and setter names to [Resurrector] functions.
+  ///
+  /// Access and mutation of properties listed in this map will be replayed
+  /// by looking for matching property accesses in the [manifest] and
+  /// resurrecting the invocation return value using the values in this map.
+  ///
+  /// The keys for property getters are the simple property names, whereas the
+  /// keys for property setters are the property names followed by an equals
+  /// sign (e.g. `propertyName=`).
   @protected
   final Map<Symbol, Resurrector> properties = <Symbol, Resurrector>{};
 
-  /// TODO(tvolkert): document
+  /// The unique identifier of this replay object.
+  ///
+  /// When replay objects are returned as a result of a call, they are returned
+  /// only as an opaque identifier. When those objects are then used as the
+  /// invocation target, the same identifier is used in the serialized
+  /// recording.
   String get identifier;
 
-  /// TODO(tvolkert): document
+  /// The manifest of recorded invocation events.
+  ///
+  /// This manifest exists as `MANIFEST.txt` in a recording directory.
   List<Map<String, dynamic>> get manifest;
 
   @override

--- a/lib/src/backends/record_replay/replay_proxy_mixin.dart
+++ b/lib/src/backends/record_replay/replay_proxy_mixin.dart
@@ -52,8 +52,8 @@ int _nextOrdinal = 0;
 ///         });
 ///
 ///         properties.addAll(<Symbol, Resurrector>{
-///           #sampleProperty: resurrectFoo,
-///           const Symbol('sampleProperty='): resurrectPassthrough,
+///           #sampleParent: resurrectFoo,
+///           const Symbol('sampleParent='): resurrectPassthrough,
 ///         });
 ///       }
 ///     }
@@ -62,7 +62,7 @@ abstract class ReplayProxyMixin implements ProxyObject {
   ///
   /// Invocations of methods listed in this map will be replayed by looking for
   /// matching invocations in the [manifest] and resurrecting the invocation
-  /// return value using the values in this map.
+  /// return value using the [Resurrector] found in this map.
   @protected
   final Map<Symbol, Resurrector> methods = <Symbol, Resurrector>{};
 
@@ -70,7 +70,8 @@ abstract class ReplayProxyMixin implements ProxyObject {
   ///
   /// Access and mutation of properties listed in this map will be replayed
   /// by looking for matching property accesses in the [manifest] and
-  /// resurrecting the invocation return value using the values in this map.
+  /// resurrecting the invocation return value using the [Resurrector] found
+  /// in this map.
   ///
   /// The keys for property getters are the simple property names, whereas the
   /// keys for property setters are the property names followed by an equals
@@ -80,11 +81,12 @@ abstract class ReplayProxyMixin implements ProxyObject {
 
   /// The unique identifier of this replay object.
   ///
-  /// When replay-aware objects are serialized in a recorded, they are done so
+  /// When replay-aware objects are serialized in a recording, they are done so
   /// using only a unique String identifier. When the objects are resurrected
-  /// for the purpose of replay, their identifier is used to find possible
-  /// invocations in the [manifest] (only invocations whose target object
-  /// matches the identifier are considered).
+  /// for the purpose of replay, their identifiers are used to match incoming
+  /// invocations against recorded invocations in the [manifest] (only
+  /// invocations whose target object matches the identifier are considered
+  /// possible matches).
   String get identifier;
 
   /// The manifest of recorded invocation events.
@@ -122,6 +124,8 @@ abstract class ReplayProxyMixin implements ProxyObject {
     return resurrector(entry[kManifestResultKey]);
   }
 
+  /// Finds the next available invocation event in the [manifest] that matches
+  /// the specified [invocation].
   Map<String, dynamic> _nextEvent(Invocation invocation) {
     _InvocationMatcher matches = _getMatcher(invocation);
     return manifest.firstWhere((Map<String, dynamic> entry) {

--- a/lib/src/backends/record_replay/resurrectors.dart
+++ b/lib/src/backends/record_replay/resurrectors.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:file/file.dart';
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as path;
+
+import 'replay_file_stat.dart';
+
+/// Resurrects an invocation result (return value) from the specified
+/// serialized [data].
+@protected
+typedef Object Resurrector(dynamic data);
+
+/// Returns a [Resurrector] that will wrap the return value of the specified
+/// [delegate] in a [Future].
+Resurrector resurrectFuture(Resurrector delegate) {
+  return (dynamic serializedResult) async {
+    return delegate(serializedResult);
+  };
+}
+
+/// Resurrects a [FileStat] from the specified serialized [data].
+FileStat resurrectFileStat(Map<String, dynamic> data) {
+  return new ReplayFileStat(data);
+}
+
+/// Resurrects a [DateTime] from the specified [milliseconds] since the epoch.
+DateTime resurrectDateTime(int milliseconds) {
+  return new DateTime.fromMillisecondsSinceEpoch(milliseconds);
+}
+
+/// Resurrects a [FileSystemEntityType] from the specified string
+/// representation.
+FileSystemEntityType resurrectFileSystemEntityType(String type) {
+  return <String, FileSystemEntityType>{
+    'FILE': FileSystemEntityType.FILE,
+    'DIRECTORY': FileSystemEntityType.DIRECTORY,
+    'LINK': FileSystemEntityType.LINK,
+    'NOT_FOUND': FileSystemEntityType.NOT_FOUND,
+  }[type];
+}
+
+/// Resurrects a value whose serialized representation is the same the real
+/// value.
+dynamic resurrectPassthrough(dynamic value) => value;
+
+/// Resurrects a [path.Context] from the specified serialized [data]
+path.Context resurrectPathContext(Map<String, String> data) {
+  return new path.Context(
+    style: <String, path.Style>{
+      'posix': path.Style.posix,
+      'windows': path.Style.windows,
+      'url': path.Style.url,
+    }[data['style']],
+    current: data['cwd'],
+  );
+}

--- a/lib/src/backends/record_replay/resurrectors.dart
+++ b/lib/src/backends/record_replay/resurrectors.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:file/file.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
 import 'replay_directory.dart';
@@ -16,7 +15,6 @@ import 'replay_link.dart';
 
 /// Resurrects an invocation result (return value) from the specified
 /// serialized [data].
-@protected
 typedef Object Resurrector(dynamic data);
 
 /// Returns a [Resurrector] that will wrap the return value of the specified

--- a/lib/src/backends/record_replay/resurrectors.dart
+++ b/lib/src/backends/record_replay/resurrectors.dart
@@ -8,7 +8,11 @@ import 'package:file/file.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
+import 'replay_directory.dart';
+import 'replay_file.dart';
 import 'replay_file_stat.dart';
+import 'replay_file_system.dart';
+import 'replay_link.dart';
 
 /// Resurrects an invocation result (return value) from the specified
 /// serialized [data].
@@ -20,6 +24,30 @@ typedef Object Resurrector(dynamic data);
 Resurrector resurrectFuture(Resurrector delegate) {
   return (dynamic serializedResult) async {
     return delegate(serializedResult);
+  };
+}
+
+/// Returns a [Resurrector] that will resurrect a [ReplayDirectory] that is
+/// tied to the specified [fileSystem].
+Resurrector resurrectDirectory(ReplayFileSystemImpl fileSystem) {
+  return (String identifier) {
+    return new ReplayDirectory(fileSystem, identifier);
+  };
+}
+
+/// Returns a [Resurrector] that will resurrect a [ReplayFile] that is tied to
+/// the specified [fileSystem].
+Resurrector resurrectFile(ReplayFileSystemImpl fileSystem) {
+  return (String identifier) {
+    return new ReplayFile(fileSystem, identifier);
+  };
+}
+
+/// Returns a [Resurrector] that will resurrect a [ReplayLink] that is tied to
+/// the specified [fileSystem].
+Resurrector resurrectLink(ReplayFileSystemImpl fileSystem) {
+  return (String identifier) {
+    return new ReplayLink(fileSystem, identifier);
   };
 }
 

--- a/lib/src/backends/record_replay/resurrectors.dart
+++ b/lib/src/backends/record_replay/resurrectors.dart
@@ -20,9 +20,7 @@ typedef Object Resurrector(dynamic data);
 /// Returns a [Resurrector] that will wrap the return value of the specified
 /// [delegate] in a [Future].
 Resurrector resurrectFuture(Resurrector delegate) {
-  return (dynamic serializedResult) async {
-    return delegate(serializedResult);
-  };
+  return (dynamic serializedResult) async => delegate(serializedResult);
 }
 
 /// Returns a [Resurrector] that will resurrect a [ReplayDirectory] that is
@@ -62,7 +60,7 @@ DateTime resurrectDateTime(int milliseconds) {
 /// Resurrects a [FileSystemEntityType] from the specified string
 /// representation.
 FileSystemEntityType resurrectFileSystemEntityType(String type) {
-  return <String, FileSystemEntityType>{
+  return const <String, FileSystemEntityType>{
     'FILE': FileSystemEntityType.FILE,
     'DIRECTORY': FileSystemEntityType.DIRECTORY,
     'LINK': FileSystemEntityType.LINK,

--- a/lib/src/testing/record_replay_matchers.dart
+++ b/lib/src/testing/record_replay_matchers.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:file/record_replay.dart';
-import 'package:file/src/backends/record_replay/common.dart';
+import 'package:file/src/backends/record_replay/common.dart' hide TypeMatcher;
 import 'package:test/test.dart';
 
 const Map<Type, String> _kTypeDescriptions = const <Type, String>{
@@ -47,6 +47,15 @@ PropertyGet getsProperty([dynamic name]) => new PropertyGet._(name);
 /// The returned [PropertySet] matcher can be used to further limit the
 /// scope of the match (e.g. by property value, target object, etc).
 PropertySet setsProperty([dynamic name]) => new PropertySet._(name);
+
+/// A matcher that successfully matches against an instance of
+/// [NoMatchingInvocationError].
+const Matcher isNoMatchingInvocationError = const _NoMatchingInvocationError();
+
+/// A matcher that successfully matches against a future or function
+/// that throws a [NoMatchingInvocationError].
+const Matcher throwsNoMatchingInvocationError =
+    const Throws(isNoMatchingInvocationError);
 
 /// Base class for matchers that match against generic [InvocationEvent]
 /// instances.
@@ -573,4 +582,12 @@ class _SetValue extends Matcher {
     description.add('to value: ');
     return _matcher.describe(description);
   }
+}
+
+class _NoMatchingInvocationError extends TypeMatcher {
+  const _NoMatchingInvocationError() : super("NoMatchingInvocationError");
+
+  @override
+  bool matches(dynamic item, Map<dynamic, dynamic> matchState) =>
+      item is NoMatchingInvocationError;
 }

--- a/test/replay_test.dart
+++ b/test/replay_test.dart
@@ -187,12 +187,4 @@ void main() {
 }
 
 /// Successfully matches against an instance of [Future].
-const Matcher isFuture = const _IsFuture();
-
-class _IsFuture extends TypeMatcher {
-  const _IsFuture() : super('Future');
-
-  @override
-  bool matches(dynamic item, Map<dynamic, dynamic> matchState) =>
-      item is Future<dynamic>;
-}
+const Matcher isFuture = const isInstanceOf<Future<dynamic>>();

--- a/test/replay_test.dart
+++ b/test/replay_test.dart
@@ -1,0 +1,198 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:file/record_replay.dart';
+import 'package:file/testing.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+void main() {
+  group('Replay', () {
+    RecordingFileSystem recordingFileSystem;
+    MemoryFileSystem memoryFileSystem;
+    LiveRecording recording;
+
+    setUp(() {
+      memoryFileSystem = new MemoryFileSystem();
+      recordingFileSystem = new RecordingFileSystem(
+        delegate: memoryFileSystem,
+        destination: new MemoryFileSystem().directory('/tmp')..createSync(),
+      );
+      recording = recordingFileSystem.recording;
+    });
+
+    /// Creates a new [ReplayFileSystem] that will replay a recording of the
+    /// events that have been recorded within [recordingFileSystem] thus far.
+    Future<ReplayFileSystem> replay() async {
+      await recording.flush();
+      return new ReplayFileSystem(recording: recording.destination);
+    }
+
+    group('ReplayFileSystem', () {
+      test('directory', () async {
+        recordingFileSystem.directory('/foo');
+        ReplayFileSystem fs = await replay();
+        Directory dir = fs.directory('/foo');
+        expect(dir, isDirectory);
+        expect(() => dir.path, throwsNoMatchingInvocationError);
+        expect(() => fs.directory('/foo'), throwsNoMatchingInvocationError);
+      });
+
+      test('file', () async {
+        recordingFileSystem.file('/foo');
+        ReplayFileSystem fs = await replay();
+        expect(fs.file('/foo'), isFile);
+        expect(() => fs.file('/foo'), throwsNoMatchingInvocationError);
+      });
+
+      test('link', () async {
+        recordingFileSystem.link('/foo');
+        ReplayFileSystem fs = await replay();
+        expect(fs.link('/foo'), isLink);
+        expect(() => fs.link('/foo'), throwsNoMatchingInvocationError);
+      });
+
+      test('path', () async {
+        path.Context context = recordingFileSystem.path;
+        ReplayFileSystem fs = await replay();
+        path.Context replayContext = fs.path;
+        expect(() => fs.path, throwsNoMatchingInvocationError);
+        expect(replayContext.style, context.style);
+        expect(replayContext.current, context.current);
+      });
+
+      test('systemTempDirectory', () async {
+        recordingFileSystem.systemTempDirectory;
+        ReplayFileSystem fs = await replay();
+        Directory dir = fs.systemTempDirectory;
+        expect(dir, isDirectory);
+        expect(() => dir.path, throwsNoMatchingInvocationError);
+        expect(() => fs.systemTempDirectory, throwsNoMatchingInvocationError);
+      });
+
+      group('currentDirectory', () {
+        test('get', () async {
+          recordingFileSystem.currentDirectory;
+          ReplayFileSystem fs = await replay();
+          Directory dir = fs.currentDirectory;
+          expect(dir, isDirectory);
+          expect(() => dir.path, throwsNoMatchingInvocationError);
+          expect(() => fs.currentDirectory, throwsNoMatchingInvocationError);
+        });
+
+        test('setToString', () async {
+          memoryFileSystem.directory('/foo').createSync();
+          recordingFileSystem.currentDirectory = '/foo';
+          ReplayFileSystem fs = await replay();
+          expect(() => fs.currentDirectory = '/bar',
+              throwsNoMatchingInvocationError);
+          fs.currentDirectory = '/foo';
+          expect(() => fs.currentDirectory = '/foo',
+              throwsNoMatchingInvocationError);
+        });
+
+        test('setToDirectory', () async {
+          Directory dir = await recordingFileSystem.directory('/foo').create();
+          recordingFileSystem.currentDirectory = dir;
+          ReplayFileSystem fs = await replay();
+          Directory replayDir = fs.directory('/foo');
+          expect(() => fs.directory('/foo'), throwsNoMatchingInvocationError);
+          fs.currentDirectory = replayDir;
+          expect(() => fs.currentDirectory = replayDir,
+              throwsNoMatchingInvocationError);
+        });
+      });
+
+      test('stat', () async {
+        FileStat stat = await recordingFileSystem.stat('/');
+        ReplayFileSystem fs = await replay();
+        Future<FileStat> replayStatFuture = fs.stat('/');
+        expect(() => fs.stat('/'), throwsNoMatchingInvocationError);
+        expect(replayStatFuture, isFuture);
+        FileStat replayStat = await replayStatFuture;
+        expect(replayStat.accessed, stat.accessed);
+        expect(replayStat.changed, stat.changed);
+        expect(replayStat.modified, stat.modified);
+        expect(replayStat.mode, stat.mode);
+        expect(replayStat.type, stat.type);
+        expect(replayStat.size, stat.size);
+        expect(replayStat.modeString(), stat.modeString());
+      });
+
+      test('statSync', () async {
+        FileStat stat = recordingFileSystem.statSync('/');
+        ReplayFileSystem fs = await replay();
+        FileStat replayStat = fs.statSync('/');
+        expect(() => fs.statSync('/'), throwsNoMatchingInvocationError);
+        expect(replayStat.accessed, stat.accessed);
+        expect(replayStat.changed, stat.changed);
+        expect(replayStat.modified, stat.modified);
+        expect(replayStat.mode, stat.mode);
+        expect(replayStat.type, stat.type);
+        expect(replayStat.size, stat.size);
+        expect(replayStat.modeString(), stat.modeString());
+      });
+
+      test('identical', () async {
+        memoryFileSystem.directory('/foo').createSync();
+        bool identical = await recordingFileSystem.identical('/', '/foo');
+        ReplayFileSystem fs = await replay();
+        Future<bool> replayIdenticalFuture = fs.identical('/', '/foo');
+        expect(
+            () => fs.identical('/', '/foo'), throwsNoMatchingInvocationError);
+        expect(replayIdenticalFuture, isFuture);
+        expect(await replayIdenticalFuture, identical);
+      });
+
+      test('identicalSync', () async {
+        memoryFileSystem.directory('/foo').createSync();
+        bool identical = recordingFileSystem.identicalSync('/', '/foo');
+        ReplayFileSystem fs = await replay();
+        bool replayIdentical = fs.identicalSync('/', '/foo');
+        expect(() => fs.identicalSync('/', '/foo'),
+            throwsNoMatchingInvocationError);
+        expect(replayIdentical, identical);
+      });
+
+      test('isWatchSupported', () async {
+        bool isWatchSupported = recordingFileSystem.isWatchSupported;
+        ReplayFileSystem fs = await replay();
+        expect(fs.isWatchSupported, isWatchSupported);
+        expect(() => fs.isWatchSupported, throwsNoMatchingInvocationError);
+      });
+
+      test('type', () async {
+        FileSystemEntityType type = await recordingFileSystem.type('/');
+        ReplayFileSystem fs = await replay();
+        Future<FileSystemEntityType> replayTypeFuture = fs.type('/');
+        expect(() => fs.type('/'), throwsNoMatchingInvocationError);
+        expect(replayTypeFuture, isFuture);
+        expect(await replayTypeFuture, type);
+      });
+
+      test('typeSync', () async {
+        FileSystemEntityType type = recordingFileSystem.typeSync('/');
+        ReplayFileSystem fs = await replay();
+        FileSystemEntityType replayType = fs.typeSync('/');
+        expect(() => fs.typeSync('/'), throwsNoMatchingInvocationError);
+        expect(replayType, type);
+      });
+    });
+  });
+}
+
+/// Successfully matches against an instance of [Future].
+const Matcher isFuture = const _IsFuture();
+
+class _IsFuture extends TypeMatcher {
+  const _IsFuture() : super('Future');
+
+  @override
+  bool matches(dynamic item, Map<dynamic, dynamic> matchState) =>
+      item is Future<dynamic>;
+}


### PR DESCRIPTION
This implements all the plumbing for `ReplayFileSystem` except
for the resurrectors for `FileSystemEntity`, `File`, `Directory`,
and `Link`. Those will land in a follow-on PR.

Part of #11