### PR TITLE
Remove 'implements Function' from MethodProxy

### DIFF
--- a/lib/src/backends/record_replay/proxy.dart
+++ b/lib/src/backends/record_replay/proxy.dart
@@ -12,7 +12,7 @@ abstract class ProxyObject {}
 /// This is used when a caller accesses a method on a [ProxyObject] via the
 /// method's getter. In these cases, the caller will receive a [MethodProxy]
 /// that allows delayed invocation of the method.
-class MethodProxy extends Object implements Function {
+class MethodProxy {
   /// The object on which the method was retrieved.
   ///
   /// This will be the target object when this method proxy is invoked.

--- a/lib/src/backends/record_replay/recording_file_system.dart
+++ b/lib/src/backends/record_replay/recording_file_system.dart
@@ -36,6 +36,22 @@ import 'replay_file_system.dart';
 ///     assertions in your tests about which methods were invoked and in what
 ///     order.
 ///
+/// *Implementation note*: this class uses [noSuchMethod] to dynamically handle
+/// invocations. As a result, method references on objects herein will not pass
+/// `is` checks or checked-mode checks on type. For example:
+///
+/// ```dart
+/// typedef FileStat StatSync(String path);
+/// FileSystem fs = new ReplayFileSystem(delegate: delegate, destination: dir);
+///
+/// StatSync method = fs.statSync;     // Will fail in checked-mode
+/// fs.statSync is StatSync            // Will return false
+/// fs.statSync is Function            // Will return false
+///
+/// dynamic method2 = fs.statSync;     // OK
+/// FileStat stat = method2('/path');  // OK
+/// ```
+///
 /// See also:
 ///   - [ReplayFileSystem]
 abstract class RecordingFileSystem extends FileSystem {

--- a/lib/src/backends/record_replay/recording_file_system.dart
+++ b/lib/src/backends/record_replay/recording_file_system.dart
@@ -42,7 +42,7 @@ import 'replay_file_system.dart';
 ///
 /// ```dart
 /// typedef FileStat StatSync(String path);
-/// FileSystem fs = new ReplayFileSystem(delegate: delegate, destination: dir);
+/// FileSystem fs = new RecordingFileSystem(delegate: delegate, destination: dir);
 ///
 /// StatSync method = fs.statSync;     // Will fail in checked-mode
 /// fs.statSync is StatSync            // Will return false

--- a/lib/src/backends/record_replay/replay_file_system.dart
+++ b/lib/src/backends/record_replay/replay_file_system.dart
@@ -41,6 +41,22 @@ import 'replay_proxy_mixin.dart';
 ///     assertions in your tests about which methods were invoked and in what
 ///     order.
 ///
+/// *Implementation note*: this class uses [noSuchMethod] to dynamically handle
+/// invocations. As a result, method references on objects herein will not pass
+/// `is` checks or checked-mode checks on type. For example:
+///
+/// ```dart
+/// typedef FileStat StatSync(String path);
+/// FileSystem fs = new ReplayFileSystem(directory);
+///
+/// StatSync method = fs.statSync;     // Will fail in checked-mode
+/// fs.statSync is StatSync            // Will return false
+/// fs.statSync is Function            // Will return false
+///
+/// dynamic method2 = fs.statSync;     // OK
+/// FileStat stat = method2('/path');  // OK
+/// ```
+///
 /// See also:
 ///   - [RecordingFileSystem]
 abstract class ReplayFileSystem extends FileSystem {

--- a/test/common_tests.dart
+++ b/test/common_tests.dart
@@ -2276,7 +2276,7 @@ void runCommonTests(
             });
 
             test('blocksCallToFlushWhileStreamIsActive', () {
-              expect(sink.flush, throwsStateError);
+              expect(() => sink.flush(), throwsStateError);
             });
           });
         });


### PR DESCRIPTION
The ability to implement the `Function` interface has been
deprecated in the SDK. This change also adds dartdoc explaining
the implications of our use of `noSuchMethod` in the record_replay
library.