### PR TITLE
Enable Windows testing of MemoryFileSystem

### DIFF
--- a/appvyor.yml
+++ b/appvyor.yml
@@ -1,0 +1,13 @@
+install:
+  - choco install dart-sdk
+  - ps: refreshenv
+  - refreshenv
+  - set DART_DIR=c:\tools\dart-sdk\bin
+  - set PUB_EXECUTABLE=pub.bat
+  - ps: pwd
+  - pub get
+
+build: off
+
+test_script:
+  - pub run test test\memory_test.dart

--- a/appvyor.yml
+++ b/appvyor.yml
@@ -10,4 +10,5 @@ install:
 build: off
 
 test_script:
+  # TODO(tvolkert): Broaden scope of tests
   - pub run test test\memory_test.dart


### PR DESCRIPTION
LocalFileSystem exposes a number of bugs in the Dart VM on Windows,
so for now we'll skip those, but this at least ensures that MemoryFileSystem
will have Windows testing, since it has no excuse to not run on Windows.

First step in #51