### PR TITLE
Make the test async so as to wait for write to be done

### DIFF
--- a/test/common_tests.dart
+++ b/test/common_tests.dart
@@ -2188,7 +2188,7 @@ void runCommonTests(
             isSinkClosed = true;
           });
 
-          test('throwsIfEncodingIsNullAndWriteObject', () {
+          test('throwsIfEncodingIsNullAndWriteObject', () async {
             sink.encoding = null;
             expect(() => sink.write('Hello world'), throwsNoSuchMethodError);
           });


### PR DESCRIPTION
This fixes the test failure in sdk 1.24.0.

@tvolkert  