### PR TITLE
Fix line splitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 2.3.5
+
+* Fix internal use of a cast which fails on Dart 2.0 .
+
 #### 2.3.4
 
 * Bumped maximum Dart SDK version to 2.0.0-dev.infinity

--- a/lib/src/backends/record_replay/codecs.dart
+++ b/lib/src/backends/record_replay/codecs.dart
@@ -85,6 +85,32 @@ class _GenericEncoder extends Converter<dynamic, dynamic> {
   }
 }
 
+/// A trivial conversion turning a Sink<List<String>> into a
+/// Sink<String>
+class _StringSinkWrapper implements Sink<String> {
+  Sink<List<String>> _sink;
+  _StringSinkWrapper(this._sink);
+  @override
+  void add(String s) => _sink.add(<String>[s]);
+  @override
+  void close() => _sink.close();
+}
+
+/// An Converter version of the dart:convert LineSplitter (which in
+/// 2.0 no longer implements the Converter interface)
+class LineSplitterConverter extends Converter<String, List<String>> {
+  final LineSplitter _splitter = const LineSplitter();
+
+  /// Creates a new [LineSplitterConverter]
+  const LineSplitterConverter();
+
+  @override
+  List<String> convert(String input) => _splitter.convert(input);
+  @override
+  StringConversionSink startChunkedConversion(Sink<List<String>> sink) =>
+      _splitter.startChunkedConversion(new _StringSinkWrapper(sink));
+}
+
 /// Converter that leaves an object untouched.
 class Passthrough<T> extends Converter<T, T> {
   /// Creates a new [Passthrough].

--- a/lib/src/backends/record_replay/codecs.dart
+++ b/lib/src/backends/record_replay/codecs.dart
@@ -88,7 +88,7 @@ class _GenericEncoder extends Converter<dynamic, dynamic> {
 /// A trivial conversion turning a Sink<List<String>> into a
 /// Sink<String>
 class _StringSinkWrapper implements Sink<String> {
-  Sink<List<String>> _sink;
+  final Sink<List<String>> _sink;
   _StringSinkWrapper(this._sink);
   @override
   void add(String s) => _sink.add(<String>[s]);

--- a/lib/src/backends/record_replay/replay_file.dart
+++ b/lib/src/backends/record_replay/replay_file.dart
@@ -25,7 +25,7 @@ class ReplayFile extends ReplayFileSystemEntity implements File {
     Converter<String, RandomAccessFile> reviveRandomAccessFile =
         new ReviveRandomAccessFile(fileSystem);
     Converter<String, List<String>> lineSplitter =
-        const LineSplitter() as Converter<String, List<String>>;
+        const LineSplitterConverter();
     Converter<String, List<String>> blobToLines =
         blobToString.fuse(lineSplitter);
     Converter<String, Stream<List<int>>> blobToByteStream = blobToBytes

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 2.3.4
+version: 2.3.5
 authors:
 - Matan Lurey <matanl@google.com>
 - Yegor Jbanov <yjbanov@google.com>


### PR DESCRIPTION
This fixes https://github.com/dart-lang/sdk/issues/28748 .

LineSplitter has been in an odd state for a while where it implements Converter in Dart 1.0 but not in 2.0.  We've made the change in the Dart 2.0 repository to flip it entirely away from Converter.  This adds a wrapper implementation that satisfies the Converter interface.