### PR TITLE
Fix impl of memory directory's _renameSync.

### DIFF
--- a/lib/src/backends/memory/memory_directory.dart
+++ b/lib/src/backends/memory/memory_directory.dart
@@ -73,8 +73,8 @@ class _MemoryDirectory extends _MemoryFileSystemEntity
   @override
   Directory renameSync(String newPath) => _renameSync(
         newPath,
-        validateOverwriteExistingEntity: (_DirectoryNode existingNode) {
-          if (existingNode.children.isNotEmpty) {
+        validateOverwriteExistingEntity: (_Node existingNode) {
+          if ((existingNode as _DirectoryNode).children.isNotEmpty) {
             throw common.directoryNotEmpty(newPath);
           }
         },

--- a/lib/src/backends/memory/memory_directory.dart
+++ b/lib/src/backends/memory/memory_directory.dart
@@ -71,10 +71,10 @@ class _MemoryDirectory extends _MemoryFileSystemEntity
   Future<Directory> rename(String newPath) async => renameSync(newPath);
 
   @override
-  Directory renameSync(String newPath) => _renameSync(
+  Directory renameSync(String newPath) => _renameSync<_DirectoryNode>(
         newPath,
-        validateOverwriteExistingEntity: (_Node existingNode) {
-          if ((existingNode as _DirectoryNode).children.isNotEmpty) {
+        validateOverwriteExistingEntity: (_DirectoryNode existingNode) {
+          if (existingNode.children.isNotEmpty) {
             throw common.directoryNotEmpty(newPath);
           }
         },

--- a/lib/src/backends/memory/memory_file_system_entity.dart
+++ b/lib/src/backends/memory/memory_file_system_entity.dart
@@ -207,9 +207,9 @@ abstract class _MemoryFileSystemEntity implements FileSystemEntity {
   /// If [checkType] is specified, it will be used to validate that the file
   /// system entity that exists at [path] is of the expected type. By default,
   /// [_defaultCheckType] is used to perform this validation.
-  FileSystemEntity _renameSync(
+  FileSystemEntity _renameSync<T extends _Node>(
     String newPath, {
-    _RenameOverwriteValidator<_Node> validateOverwriteExistingEntity,
+    _RenameOverwriteValidator<T> validateOverwriteExistingEntity,
     bool followTailLink: false,
     _TypeChecker checkType,
   }) {

--- a/lib/src/backends/memory/memory_file_system_entity.dart
+++ b/lib/src/backends/memory/memory_file_system_entity.dart
@@ -209,7 +209,7 @@ abstract class _MemoryFileSystemEntity implements FileSystemEntity {
   /// [_defaultCheckType] is used to perform this validation.
   FileSystemEntity _renameSync(
     String newPath, {
-    _RenameOverwriteValidator<dynamic> validateOverwriteExistingEntity,
+    _RenameOverwriteValidator<_DirectoryNode> validateOverwriteExistingEntity,
     bool followTailLink: false,
     _TypeChecker checkType,
   }) {

--- a/lib/src/backends/memory/memory_file_system_entity.dart
+++ b/lib/src/backends/memory/memory_file_system_entity.dart
@@ -209,7 +209,7 @@ abstract class _MemoryFileSystemEntity implements FileSystemEntity {
   /// [_defaultCheckType] is used to perform this validation.
   FileSystemEntity _renameSync(
     String newPath, {
-    _RenameOverwriteValidator<_DirectoryNode> validateOverwriteExistingEntity,
+    _RenameOverwriteValidator<_Node> validateOverwriteExistingEntity,
     bool followTailLink: false,
     _TypeChecker checkType,
   }) {


### PR DESCRIPTION
Fixes #65.

In the first commit of PR #63, I think analyzer should have warned me that the `_RenameOverwriteValidator<_DirectoryNode>` callback was being passed a `_Node`, but it didn't! https://github.com/dart-lang/sdk/issues/31410 I think. [simplified dartpad](https://dartpad.dartlang.org/adc68f958ebb8d3ec8bef1d1f01a4812)

The alternative to this fix is type-annotating `_renameSync` with a T, and declaring `validateOverwriteExistingEntity` to be a `_RenameOverwriteValidator<T>`.