### PR TITLE
Update sdk constraint to <2.0.0. 

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,4 +16,4 @@ dev_dependencies:
   test: ^0.12.18
 
 environment:
-  sdk: '>=1.19.0 <2.0.0-dev.infinity'
+  sdk: '>=1.19.0 <2.0.0'


### PR DESCRIPTION
This drops '-dev.infinity' from sdk constraint, which seems to be per outdated guidelines.

Besides it prevents use of the package with 'edge'-based dart sdk.