### PR TITLE
Allow dev to fail on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ dart:
   - stable
   - dev
 script: ./tool/travis.sh
+matrix:
+  allow_failures:
+    - dart: dev


### PR DESCRIPTION
Only marks the build red if stable fails.