### PR TITLE
Make ForwardingDirectory generic.

### DIFF
--- a/lib/src/forwarding/forwarding_directory.dart
+++ b/lib/src/forwarding/forwarding_directory.dart
@@ -5,11 +5,11 @@
 part of file.src.forwarding;
 
 /// A directory that forwards all methods and properties to a delegate.
-abstract class ForwardingDirectory
-    extends ForwardingFileSystemEntity<Directory, io.Directory>
+abstract class ForwardingDirectory<T extends Directory>
+    extends ForwardingFileSystemEntity<T, io.Directory>
     implements Directory {
   @override
-  ForwardingDirectory wrap(io.Directory delegate) => wrapDirectory(delegate);
+  T wrap(io.Directory delegate) => wrapDirectory(delegate);
 
   @override
   Future<Directory> create({bool recursive: false}) async =>

--- a/lib/src/forwarding/forwarding_directory.dart
+++ b/lib/src/forwarding/forwarding_directory.dart
@@ -6,8 +6,7 @@ part of file.src.forwarding;
 
 /// A directory that forwards all methods and properties to a delegate.
 abstract class ForwardingDirectory<T extends Directory>
-    extends ForwardingFileSystemEntity<T, io.Directory>
-    implements Directory {
+    extends ForwardingFileSystemEntity<T, io.Directory> implements Directory {
   @override
   T wrap(io.Directory delegate) => wrapDirectory(delegate);
 


### PR DESCRIPTION
Due to an upcoming change in Dart 2.0
(https://github.com/dart-lang/sdk/issues/32148), it will no longer be
allowed for a class to implement the same generic interface in
different ways.  (E.g. a class cannot implement/extend/mixin both
A<int> and A<String>).

This causes problems with _LocalDirectory.  It extends
_LocalFileSystemEntity<_LocalDirectory, Directory>, which extends
ForwardingFileSystemEntity<_LocalDirectory, Directory>, but it mixes
in ForwardingDirectory, which extends
ForwardingFileSystemEntity<Directory, io.Directory>.

The solution is to make ForwardingDirectory a generic mixin, with
ForwardingDirectory<T> extending ForwardingFileSystemEntity<T,
io.Directory>.  Type inference automatically fills in the type
argument T=_LocalDirectory at the site of the declaration of
_LocalDirectory.