### PR TITLE
General cleanup of package:file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ### Dart template
 # Don’t commit the following directories created by pub.
 .buildlog
+.dart_tool/
 .pub/
 build/
 packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: dart
 
 dart:
-  - stable
   - dev
 
 dart_task:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-#### 4.0.0 
+#### 4.0.1
 
-* Change method signature for `RecordingRandomAccessFile._close` to return a 
-  `Future<void>` instead of `Future<RandomAccessFile>`. This follows a change in 
+* General library cleanup
+
+#### 4.0.0
+
+* Change method signature for `RecordingRandomAccessFile._close` to return a
+  `Future<void>` instead of `Future<RandomAccessFile>`. This follows a change in
   dart:io, Dart SDK `2.0.0-dev.40`.
 
 #### 3.0.0

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,8 @@
 analyzer:
-  strong-mode: true
+  strong-mode:
+    implicit-dynamic: false
   language:
-    enableStrictCallChecks: true
+    enablePreviewDart2: true
     enableSuperMixins: true
   errors:
     # treat missing required parameters as a warning (not a hint)
@@ -63,7 +64,7 @@ linter:
     - type_annotate_public_apis
     - type_init_formals
     # TODO - unawaited_futures (https://github.com/dart-lang/linter/issues/419)
-    - unnecessary_brace_in_string_interp
+    - unnecessary_brace_in_string_interps
     - unnecessary_getters_setters
 
     # === pub rules ===

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,14 @@
 install:
-  - choco install dart-sdk
+  - ps: wget https://storage.googleapis.com/dart-archive/channels/dev/release/latest/sdk/dartsdk-windows-x64-release.zip -OutFile dart-sdk.zip
+  - cmd: echo "Unzipping dart-sdk..."
+  - cmd: 7z x dart-sdk.zip -o"C:\tools" -y > nul
   - ps: refreshenv
-  - refreshenv
-  - set DART_DIR=c:\tools\dart-sdk\bin
-  - set PUB_EXECUTABLE=pub.bat
+  - set PATH=%PATH%;C:\tools\dart-sdk\bin
+  - set PATH=%PATH%;%APPDATA%\Pub\Cache\bin
   - ps: pwd
   - pub get
 
 build: off
 
 test_script:
-  - pub run test
+  - pub run test -j1

--- a/lib/src/backends/chroot/chroot_directory.dart
+++ b/lib/src/backends/chroot/chroot_directory.dart
@@ -5,7 +5,7 @@
 part of file.src.backends.chroot;
 
 class _ChrootDirectory extends _ChrootFileSystemEntity<Directory, io.Directory>
-    with ForwardingDirectory, common.DirectoryAddOnsMixin {
+    with ForwardingDirectory<Directory>, common.DirectoryAddOnsMixin {
   _ChrootDirectory(ChrootFileSystem fs, String path) : super(fs, path);
 
   factory _ChrootDirectory.wrapped(

--- a/lib/src/backends/chroot/chroot_file.dart
+++ b/lib/src/backends/chroot/chroot_file.dart
@@ -257,7 +257,7 @@ class _ChrootFile extends _ChrootFileSystemEntity<File, io.File>
   @override
   IOSink openWrite({
     FileMode mode: FileMode.WRITE,
-    Encoding encoding: UTF8,
+    Encoding encoding: utf8,
   }) =>
       getDelegate(followLinks: true).openWrite(mode: mode, encoding: encoding);
 
@@ -270,19 +270,19 @@ class _ChrootFile extends _ChrootFileSystemEntity<File, io.File>
       getDelegate(followLinks: true).readAsBytesSync();
 
   @override
-  Future<String> readAsString({Encoding encoding: UTF8}) =>
+  Future<String> readAsString({Encoding encoding: utf8}) =>
       getDelegate(followLinks: true).readAsString(encoding: encoding);
 
   @override
-  String readAsStringSync({Encoding encoding: UTF8}) =>
+  String readAsStringSync({Encoding encoding: utf8}) =>
       getDelegate(followLinks: true).readAsStringSync(encoding: encoding);
 
   @override
-  Future<List<String>> readAsLines({Encoding encoding: UTF8}) =>
+  Future<List<String>> readAsLines({Encoding encoding: utf8}) =>
       getDelegate(followLinks: true).readAsLines(encoding: encoding);
 
   @override
-  List<String> readAsLinesSync({Encoding encoding: UTF8}) =>
+  List<String> readAsLinesSync({Encoding encoding: utf8}) =>
       getDelegate(followLinks: true).readAsLinesSync(encoding: encoding);
 
   @override
@@ -310,7 +310,7 @@ class _ChrootFile extends _ChrootFileSystemEntity<File, io.File>
   Future<File> writeAsString(
     String contents, {
     FileMode mode: FileMode.WRITE,
-    Encoding encoding: UTF8,
+    Encoding encoding: utf8,
     bool flush: false,
   }) async =>
       wrap(await getDelegate(followLinks: true).writeAsString(
@@ -324,7 +324,7 @@ class _ChrootFile extends _ChrootFileSystemEntity<File, io.File>
   void writeAsStringSync(
     String contents, {
     FileMode mode: FileMode.WRITE,
-    Encoding encoding: UTF8,
+    Encoding encoding: utf8,
     bool flush: false,
   }) =>
       getDelegate(followLinks: true).writeAsStringSync(

--- a/lib/src/backends/local.dart
+++ b/lib/src/backends/local.dart
@@ -2,18 +2,4 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library file.src.backends.local;
-
-import 'dart:async';
-
-import 'package:file/src/common.dart' as common;
-import 'package:file/src/forwarding.dart';
-import 'package:file/src/io.dart' as io;
-import 'package:file/file.dart';
-import 'package:path/path.dart' as p;
-
-part 'local/local_directory.dart';
-part 'local/local_file.dart';
-part 'local/local_file_system.dart';
-part 'local/local_file_system_entity.dart';
-part 'local/local_link.dart';
+export 'local/local_file_system.dart' show LocalFileSystem;

--- a/lib/src/backends/local/local_directory.dart
+++ b/lib/src/backends/local/local_directory.dart
@@ -2,12 +2,19 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of file.src.backends.local;
+import 'package:file/src/common.dart' as common;
+import 'package:file/src/forwarding.dart';
+import 'package:file/src/io.dart' as io;
+import 'package:file/file.dart';
 
-class _LocalDirectory
-    extends _LocalFileSystemEntity<_LocalDirectory, io.Directory>
-    with ForwardingDirectory, common.DirectoryAddOnsMixin {
-  _LocalDirectory(FileSystem fs, io.Directory delegate) : super(fs, delegate);
+import 'local_file_system_entity.dart';
+
+/// [Directory] implementation that forwards all calls to `dart:io`.
+class LocalDirectory extends LocalFileSystemEntity<LocalDirectory, io.Directory>
+    with ForwardingDirectory<LocalDirectory>, common.DirectoryAddOnsMixin {
+  /// Instantiates a new [LocalDirectory] tied to the specified file system
+  /// and delegating to the specified [delegate].
+  LocalDirectory(FileSystem fs, io.Directory delegate) : super(fs, delegate);
 
   @override
   String toString() => "LocalDirectory: '$path'";

--- a/lib/src/backends/local/local_file.dart
+++ b/lib/src/backends/local/local_file.dart
@@ -2,11 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of file.src.backends.local;
+import 'package:file/src/forwarding.dart';
+import 'package:file/src/io.dart' as io;
+import 'package:file/file.dart';
 
-class _LocalFile extends _LocalFileSystemEntity<File, io.File>
+import 'local_file_system_entity.dart';
+
+/// [File] implementation that forwards all calls to `dart:io`.
+class LocalFile extends LocalFileSystemEntity<File, io.File>
     with ForwardingFile {
-  _LocalFile(FileSystem fs, io.File delegate) : super(fs, delegate);
+  /// Instantiates a new [LocalFile] tied to the specified file system
+  /// and delegating to the specified [delegate].
+  LocalFile(FileSystem fs, io.File delegate) : super(fs, delegate);
 
   @override
   String toString() => "LocalFile: '$path'";

--- a/lib/src/backends/local/local_file_system.dart
+++ b/lib/src/backends/local/local_file_system.dart
@@ -2,7 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of file.src.backends.local;
+import 'dart:async';
+
+import 'package:file/src/io.dart' as io;
+import 'package:file/file.dart';
+import 'package:path/path.dart' as p;
+
+import 'local_directory.dart';
+import 'local_file.dart';
+import 'local_link.dart';
 
 /// A wrapper implementation around `dart:io`'s implementation.
 ///
@@ -14,13 +22,13 @@ class LocalFileSystem extends FileSystem {
 
   @override
   Directory directory(dynamic path) =>
-      new _LocalDirectory(this, new io.Directory(getPath(path)));
+      new LocalDirectory(this, new io.Directory(getPath(path)));
 
   @override
-  File file(dynamic path) => new _LocalFile(this, new io.File(getPath(path)));
+  File file(dynamic path) => new LocalFile(this, new io.File(getPath(path)));
 
   @override
-  Link link(dynamic path) => new _LocalLink(this, new io.Link(getPath(path)));
+  Link link(dynamic path) => new LocalLink(this, new io.Link(getPath(path)));
 
   @override
   p.Context get path => new p.Context();
@@ -30,7 +38,7 @@ class LocalFileSystem extends FileSystem {
   /// platform-dependent, and may be set by an environment variable.
   @override
   Directory get systemTempDirectory =>
-      new _LocalDirectory(this, io.Directory.systemTemp);
+      new LocalDirectory(this, io.Directory.systemTemp);
 
   @override
   Directory get currentDirectory => directory(io.Directory.current.path);

--- a/lib/src/backends/local/local_file_system_entity.dart
+++ b/lib/src/backends/local/local_file_system_entity.dart
@@ -2,9 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of file.src.backends.local;
+import 'package:file/src/forwarding.dart';
+import 'package:file/src/io.dart' as io;
+import 'package:file/file.dart';
 
-abstract class _LocalFileSystemEntity<T extends FileSystemEntity,
+import 'local_directory.dart';
+import 'local_file.dart';
+import 'local_link.dart';
+
+/// [FileSystemEntity] implementation that forwards all calls to `dart:io`.
+abstract class LocalFileSystemEntity<T extends FileSystemEntity,
     D extends io.FileSystemEntity> extends ForwardingFileSystemEntity<T, D> {
   @override
   final FileSystem fileSystem;
@@ -12,7 +19,9 @@ abstract class _LocalFileSystemEntity<T extends FileSystemEntity,
   @override
   final D delegate;
 
-  _LocalFileSystemEntity(this.fileSystem, this.delegate);
+  /// Instantiates a new [LocalFileSystemEntity] tied to the specified file
+  /// system and delegating to the specified [delegate].
+  LocalFileSystemEntity(this.fileSystem, this.delegate);
 
   @override
   String get dirname => fileSystem.path.dirname(path);
@@ -22,11 +31,11 @@ abstract class _LocalFileSystemEntity<T extends FileSystemEntity,
 
   @override
   Directory wrapDirectory(io.Directory delegate) =>
-      new _LocalDirectory(fileSystem, delegate);
+      new LocalDirectory(fileSystem, delegate);
 
   @override
-  File wrapFile(io.File delegate) => new _LocalFile(fileSystem, delegate);
+  File wrapFile(io.File delegate) => new LocalFile(fileSystem, delegate);
 
   @override
-  Link wrapLink(io.Link delegate) => new _LocalLink(fileSystem, delegate);
+  Link wrapLink(io.Link delegate) => new LocalLink(fileSystem, delegate);
 }

--- a/lib/src/backends/local/local_link.dart
+++ b/lib/src/backends/local/local_link.dart
@@ -2,11 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of file.src.backends.local;
+import 'package:file/src/forwarding.dart';
+import 'package:file/src/io.dart' as io;
+import 'package:file/file.dart';
 
-class _LocalLink extends _LocalFileSystemEntity<Link, io.Link>
+import 'local_file_system_entity.dart';
+
+/// [Link] implementation that forwards all calls to `dart:io`.
+class LocalLink extends LocalFileSystemEntity<Link, io.Link>
     with ForwardingLink {
-  _LocalLink(FileSystem fs, io.Link delegate) : super(fs, delegate);
+  /// Instantiates a new [LocalLink] tied to the specified file system
+  /// and delegating to the specified [delegate].
+  LocalLink(FileSystem fs, io.Link delegate) : super(fs, delegate);
 
   @override
   String toString() => "LocalLink: '$path'";

--- a/lib/src/backends/memory.dart
+++ b/lib/src/backends/memory.dart
@@ -2,22 +2,4 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library file.src.backends.memory;
-
-import 'dart:async';
-import 'dart:convert';
-import 'dart:math' show min;
-
-import 'package:file/file.dart';
-import 'package:file/src/common.dart' as common;
-import 'package:file/src/io.dart' as io;
-import 'package:path/path.dart' as p;
-
-part 'memory/memory_directory.dart';
-part 'memory/memory_file.dart';
-part 'memory/memory_file_stat.dart';
-part 'memory/memory_file_system.dart';
-part 'memory/memory_file_system_entity.dart';
-part 'memory/memory_link.dart';
-part 'memory/node.dart';
-part 'memory/utils.dart';
+export 'memory/memory_file_system.dart' show MemoryFileSystem;

--- a/lib/src/backends/memory/common.dart
+++ b/lib/src/backends/memory/common.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:file/src/common.dart' as common;
+
+/// The file separator.
+const String separator = '/';
+
+/// Generates a path to use in error messages.
+typedef dynamic PathGenerator();
+
+/// Throws a `FileSystemException` if [object] is null.
+void checkExists(Object object, PathGenerator path) {
+  if (object == null) {
+    throw common.noSuchFileOrDirectory(path());
+  }
+}

--- a/lib/src/backends/memory/memory_file_stat.dart
+++ b/lib/src/backends/memory/memory_file_stat.dart
@@ -2,11 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of file.src.backends.memory;
+import 'package:file/src/io.dart' as io;
 
-class _MemoryFileStat implements io.FileStat {
-  static const _MemoryFileStat _notFound =
-      const _MemoryFileStat._internalNotFound();
+/// Internal implementation of [io.FileStat].
+class MemoryFileStat implements io.FileStat {
+  /// Shared instance representing a non-existent entity.
+  static const MemoryFileStat notFound =
+      const MemoryFileStat._internalNotFound();
 
   @override
   final DateTime changed;
@@ -26,7 +28,8 @@ class _MemoryFileStat implements io.FileStat {
   @override
   final int size;
 
-  _MemoryFileStat(
+  /// Creates a new [MemoryFileStat] with the specified properties.
+  const MemoryFileStat(
     this.changed,
     this.modified,
     this.accessed,
@@ -35,7 +38,7 @@ class _MemoryFileStat implements io.FileStat {
     this.size,
   );
 
-  const _MemoryFileStat._internalNotFound()
+  const MemoryFileStat._internalNotFound()
       : changed = null,
         modified = null,
         accessed = null,

--- a/lib/src/backends/memory/memory_file_system.dart
+++ b/lib/src/backends/memory/memory_file_system.dart
@@ -35,7 +35,7 @@ abstract class MemoryFileSystem implements FileSystem {
   ///
   /// The file system will be empty, and the current directory will be the
   /// root directory.
-  factory MemoryFileSystem() => new _MemoryFileSystem();
+  factory MemoryFileSystem() = _MemoryFileSystem;
 }
 
 /// Internal implementation of [MemoryFileSystem].

--- a/lib/src/backends/memory/memory_file_system.dart
+++ b/lib/src/backends/memory/memory_file_system.dart
@@ -2,37 +2,22 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of file.src.backends.memory;
+import 'dart:async';
 
-const String _separator = '/';
+import 'package:file/file.dart';
+import 'package:file/src/io.dart' as io;
+import 'package:path/path.dart' as p;
+
+import 'common.dart';
+import 'memory_directory.dart';
+import 'memory_file.dart';
+import 'memory_file_stat.dart';
+import 'memory_link.dart';
+import 'node.dart';
+import 'utils.dart' as utils;
+
 const String _thisDir = '.';
 const String _parentDir = '..';
-
-/// Visitor callback for use with `_findNode`.
-///
-/// [parent] is the parent node of the current path segment and is guaranteed
-/// to be non-null.
-///
-/// [childName] is the basename of the entity at the current path segment. It
-/// is guaranteed to be non-null.
-///
-/// [childNode] is the node at the current path segment. It will be
-/// non-null only if such an entity exists. The return value of this callback
-/// will be used as the value of this node, which allows this callback to
-/// do things like recursively create or delete folders.
-///
-/// [currentSegment] is the index of the current segment within the overall
-/// path that's being walked by `_findNode`.
-///
-/// [finalSegment] is the index of the final segment that will be walked by
-/// `_findNode`.
-typedef _Node _SegmentVisitor(
-  _DirectoryNode parent,
-  String childName,
-  _Node childNode,
-  int currentSegment,
-  int finalSegment,
-);
 
 /// An implementation of [FileSystem] that exists entirely in memory with an
 /// internal representation loosely based on the Filesystem Hierarchy Standard.
@@ -43,31 +28,45 @@ typedef _Node _SegmentVisitor(
 /// caching or staging before writing or reading to a live system.
 ///
 /// This implementation of the [FileSystem] interface does not directly use
-/// any `dart:io` APIs; it merely uses the library's enum values and deals in
-/// the library types. As such, it is suitable for use in the browser as soon
-/// as [#28078](https://github.com/dart-lang/sdk/issues/28078) is resolved.
-class MemoryFileSystem extends FileSystem {
-  _RootNode _root;
+/// any `dart:io` APIs; it merely uses the library's enum values and interfaces.
+/// As such, it is suitable for use in the browser.
+abstract class MemoryFileSystem implements FileSystem {
+  /// Creates a new `MemoryFileSystem`.
+  ///
+  /// The file system will be empty, and the current directory will be the
+  /// root directory.
+  factory MemoryFileSystem() => new _MemoryFileSystem();
+}
+
+/// Internal implementation of [MemoryFileSystem].
+class _MemoryFileSystem extends FileSystem
+    implements MemoryFileSystem, NodeBasedFileSystem {
+  RootNode _root;
   String _systemTemp;
-  String _cwd = _separator;
+  String _cwd = separator;
 
   /// Creates a new `MemoryFileSystem`.
   ///
   /// The file system will be empty, and the current directory will be the
   /// root directory.
-  MemoryFileSystem() {
-    _root = new _RootNode(this);
+  _MemoryFileSystem() {
+    _root = new RootNode(this);
   }
 
   @override
-  Directory directory(dynamic path) =>
-      new _MemoryDirectory(this, getPath(path));
+  RootNode get root => _root;
 
   @override
-  File file(dynamic path) => new _MemoryFile(this, getPath(path));
+  String get cwd => _cwd;
 
   @override
-  Link link(dynamic path) => new _MemoryLink(this, getPath(path));
+  Directory directory(dynamic path) => new MemoryDirectory(this, getPath(path));
+
+  @override
+  File file(dynamic path) => new MemoryFile(this, getPath(path));
+
+  @override
+  Link link(dynamic path) => new MemoryLink(this, getPath(path));
 
   @override
   p.Context get path => new p.Context(style: p.Style.posix, current: _cwd);
@@ -77,7 +76,7 @@ class MemoryFileSystem extends FileSystem {
   /// the life of the process.
   @override
   Directory get systemTempDirectory {
-    _systemTemp ??= directory(_separator).createTempSync('.tmp_').path;
+    _systemTemp ??= directory(separator).createTempSync('.tmp_').path;
     return directory(_systemTemp)..createSync();
   }
 
@@ -96,10 +95,10 @@ class MemoryFileSystem extends FileSystem {
     }
 
     value = directory(value).resolveSymbolicLinksSync();
-    _Node node = _findNode(value);
-    _checkExists(node, () => value);
-    _checkIsDir(node, () => value);
-    assert(_isAbsolute(value));
+    Node node = findNode(value);
+    checkExists(node, () => value);
+    utils.checkIsDir(node, () => value);
+    assert(utils.isAbsolute(value));
     _cwd = value;
   }
 
@@ -109,9 +108,9 @@ class MemoryFileSystem extends FileSystem {
   @override
   io.FileStat statSync(String path) {
     try {
-      return _findNode(path)?.stat ?? _MemoryFileStat._notFound;
+      return findNode(path)?.stat ?? MemoryFileStat.notFound;
     } on io.FileSystemException {
-      return _MemoryFileStat._notFound;
+      return MemoryFileStat.notFound;
     }
   }
 
@@ -121,10 +120,10 @@ class MemoryFileSystem extends FileSystem {
 
   @override
   bool identicalSync(String path1, String path2) {
-    _Node node1 = _findNode(path1);
-    _checkExists(node1, () => path1);
-    _Node node2 = _findNode(path2);
-    _checkExists(node2, () => path2);
+    Node node1 = findNode(path1);
+    checkExists(node1, () => path1);
+    Node node2 = findNode(path2);
+    checkExists(node2, () => path2);
     return node1 != null && node1 == node2;
   }
 
@@ -140,9 +139,9 @@ class MemoryFileSystem extends FileSystem {
 
   @override
   io.FileSystemEntityType typeSync(String path, {bool followLinks: true}) {
-    _Node node;
+    Node node;
     try {
-      node = _findNode(path, followTailLink: followLinks);
+      node = findNode(path, followTailLink: followLinks);
     } on io.FileSystemException {
       node = null;
     }
@@ -155,41 +154,13 @@ class MemoryFileSystem extends FileSystem {
   /// Gets the node backing for the current working directory. Note that this
   /// can return null if the directory has been deleted or moved from under our
   /// feet.
-  _DirectoryNode get _current => _findNode(_cwd);
+  DirectoryNode get _current => findNode(_cwd);
 
-  /// Gets the backing node of the entity at the specified path. If the tail
-  /// element of the path does not exist, this will return null. If the tail
-  /// element cannot be reached because its directory does not exist, a
-  /// [io.FileSystemException] will be thrown.
-  ///
-  /// If [path] is a relative path, it will be resolved relative to
-  /// [reference], or the current working directory if [reference] is null.
-  /// If [path] is an absolute path, [reference] will be ignored.
-  ///
-  /// If the last element in [path] represents a symbolic link, this will
-  /// return the [_LinkNode] node for the link (it will not return the
-  /// node to which the link points), unless [followTailLink] is true.
-  /// Directory links in the middle of the path will be followed in order to
-  /// find the node regardless of the value of [followTailLink].
-  ///
-  /// If [segmentVisitor] is specified, it will be invoked for every path
-  /// segment visited along the way starting where the reference (root folder
-  /// if the path is absolute) is the parent. For each segment, the return value
-  /// of [segmentVisitor] will be used as the backing node of that path
-  /// segment, thus allowing callers to create nodes on demand in the
-  /// specified path. Note that `..` and `.` segments may cause the visitor to
-  /// get invoked with the same node multiple times. When [segmentVisitor] is
-  /// invoked, for each path segment that resolves to a link node, the visitor
-  /// will visit the actual link node if [visitLinks] is true; otherwise it
-  /// will visit the target of the link node.
-  ///
-  /// If [pathWithSymlinks] is specified, the path to the node with symbolic
-  /// links explicitly broken out will be appended to the buffer. `..` and `.`
-  /// path segments will *not* be resolved and are left to the caller.
-  _Node _findNode(
+  @override
+  Node findNode(
     String path, {
-    _Node reference,
-    _SegmentVisitor segmentVisitor,
+    Node reference,
+    SegmentVisitor segmentVisitor,
     bool visitLinks: false,
     List<String> pathWithSymlinks,
     bool followTailLink: false,
@@ -198,15 +169,15 @@ class MemoryFileSystem extends FileSystem {
       throw new ArgumentError.notNull('path');
     }
 
-    if (_isAbsolute(path)) {
+    if (utils.isAbsolute(path)) {
       reference = _root;
     } else {
       reference ??= _current;
     }
 
-    List<String> parts = path.split(_separator)..removeWhere(_isEmpty);
-    _DirectoryNode directory = reference.directory;
-    _Node child = directory;
+    List<String> parts = path.split(separator)..removeWhere(utils.isEmpty);
+    DirectoryNode directory = reference.directory;
+    Node child = directory;
 
     int finalSegment = parts.length - 1;
     for (int i = 0; i <= finalSegment; i++) {
@@ -229,20 +200,19 @@ class MemoryFileSystem extends FileSystem {
         pathWithSymlinks.add(basename);
       }
 
-      _PathGenerator subpath = _subpath(parts, 0, i);
-      if (_isLink(child) && (i < finalSegment || followTailLink)) {
+      PathGenerator subpath = utils.subpath(parts, 0, i);
+      if (utils.isLink(child) && (i < finalSegment || followTailLink)) {
         if (visitLinks || segmentVisitor == null) {
           if (segmentVisitor != null) {
             child = segmentVisitor(directory, basename, child, i, finalSegment);
           }
-          child = _resolveLinks(child, subpath, ledger: pathWithSymlinks);
+          child = utils.resolveLinks(child, subpath, ledger: pathWithSymlinks);
         } else {
-          child = _resolveLinks(
+          child = utils.resolveLinks(
             child,
             subpath,
             ledger: pathWithSymlinks,
-            tailVisitor:
-                (_DirectoryNode parent, String childName, _Node child) {
+            tailVisitor: (DirectoryNode parent, String childName, Node child) {
               return segmentVisitor(parent, childName, child, i, finalSegment);
             },
           );
@@ -252,8 +222,8 @@ class MemoryFileSystem extends FileSystem {
       }
 
       if (i < finalSegment) {
-        _checkExists(child, subpath);
-        _checkIsDir(child, subpath);
+        checkExists(child, subpath);
+        utils.checkIsDir(child, subpath);
         directory = child;
       }
     }

--- a/lib/src/backends/record_replay/common.dart
+++ b/lib/src/backends/record_replay/common.dart
@@ -127,9 +127,9 @@ bool deeplyEqual(dynamic object1, dynamic object2) {
   if (object1.runtimeType != object2.runtimeType) {
     return false;
   } else if (object1 is List) {
-    return _areListsEqual(object1, object2);
+    return _areListsEqual<dynamic>(object1, object2);
   } else if (object1 is Map) {
-    return _areMapsEqual(object1, object2);
+    return _areMapsEqual<dynamic, dynamic>(object1, object2);
   } else {
     return object1 == object2;
   }

--- a/lib/src/backends/record_replay/events.dart
+++ b/lib/src/backends/record_replay/events.dart
@@ -191,8 +191,7 @@ class LiveMethodEvent<T> extends LiveInvocationEvent<T>
     T result,
     dynamic error,
     int timestamp,
-  )
-      : this.positionalArguments =
+  )   : this.positionalArguments =
             new List<dynamic>.unmodifiable(positionalArguments),
         this.namedArguments =
             new Map<Symbol, dynamic>.unmodifiable(namedArguments),

--- a/lib/src/backends/record_replay/recording_file.dart
+++ b/lib/src/backends/record_replay/recording_file.dart
@@ -99,7 +99,7 @@ class RecordingFile extends RecordingFileSystemEntity<File> implements File {
     );
   }
 
-  IOSink _openWrite({FileMode mode: FileMode.WRITE, Encoding encoding: UTF8}) {
+  IOSink _openWrite({FileMode mode: FileMode.WRITE, Encoding encoding: utf8}) {
     return new RecordingIOSink(
       fileSystem,
       delegate.openWrite(mode: mode, encoding: encoding),
@@ -126,7 +126,7 @@ class RecordingFile extends RecordingFileSystemEntity<File> implements File {
     );
   }
 
-  FutureReference<String> _readAsString({Encoding encoding: UTF8}) {
+  FutureReference<String> _readAsString({Encoding encoding: utf8}) {
     return new _BlobFutureReference<String>(
       file: _newRecordingFile(),
       future: delegate.readAsString(encoding: encoding),
@@ -136,7 +136,7 @@ class RecordingFile extends RecordingFileSystemEntity<File> implements File {
     );
   }
 
-  ResultReference<String> _readAsStringSync({Encoding encoding: UTF8}) {
+  ResultReference<String> _readAsStringSync({Encoding encoding: utf8}) {
     return new _BlobReference<String>(
       file: _newRecordingFile(),
       value: delegate.readAsStringSync(encoding: encoding),
@@ -146,7 +146,7 @@ class RecordingFile extends RecordingFileSystemEntity<File> implements File {
     );
   }
 
-  FutureReference<List<String>> _readAsLines({Encoding encoding: UTF8}) {
+  FutureReference<List<String>> _readAsLines({Encoding encoding: utf8}) {
     return new _BlobFutureReference<List<String>>(
       file: _newRecordingFile(),
       future: delegate.readAsLines(encoding: encoding),
@@ -156,7 +156,7 @@ class RecordingFile extends RecordingFileSystemEntity<File> implements File {
     );
   }
 
-  ResultReference<List<String>> _readAsLinesSync({Encoding encoding: UTF8}) {
+  ResultReference<List<String>> _readAsLinesSync({Encoding encoding: utf8}) {
     return new _BlobReference<List<String>>(
       file: _newRecordingFile(),
       value: delegate.readAsLinesSync(encoding: encoding),
@@ -176,7 +176,7 @@ class RecordingFile extends RecordingFileSystemEntity<File> implements File {
   Future<File> _writeAsString(
     String contents, {
     FileMode mode: FileMode.WRITE,
-    Encoding encoding: UTF8,
+    Encoding encoding: utf8,
     bool flush: false,
   }) =>
       delegate
@@ -194,8 +194,7 @@ class _BlobReference<T> extends ResultReference<T> {
     @required File file,
     @required T value,
     @required _BlobDataSyncWriter<T> writer,
-  })
-      : _file = file,
+  })  : _file = file,
         _value = value,
         _writer = writer;
 
@@ -221,8 +220,7 @@ class _BlobFutureReference<T> extends FutureReference<T> {
     @required File file,
     @required Future<T> future,
     @required _BlobDataAsyncWriter<T> writer,
-  })
-      : _file = file,
+  })  : _file = file,
         _writer = writer,
         super(future);
 
@@ -247,8 +245,7 @@ class _BlobStreamReference<T> extends StreamReference<T> {
     @required File file,
     @required Stream<T> stream,
     @required _BlobDataSyncWriter<T> writer,
-  })
-      : _file = file,
+  })  : _file = file,
         _writer = writer,
         super(stream);
 

--- a/lib/src/backends/record_replay/recording_random_access_file.dart
+++ b/lib/src/backends/record_replay/recording_random_access_file.dart
@@ -87,7 +87,7 @@ class RecordingRandomAccessFile extends Object
       delegate.writeFrom(buffer, start, end).then(_wrap);
 
   Future<RandomAccessFile> _writeString(String string,
-          {Encoding encoding: UTF8}) =>
+          {Encoding encoding: utf8}) =>
       delegate.writeString(string, encoding: encoding).then(_wrap);
 
   Future<RandomAccessFile> _setPosition(int position) =>

--- a/lib/src/backends/record_replay/replay_directory.dart
+++ b/lib/src/backends/record_replay/replay_directory.dart
@@ -25,6 +25,9 @@ class ReplayDirectory extends ReplayFileSystemEntity implements Directory {
         new ReviveFileSystemEntity(fileSystem);
     Converter<List<String>, List<FileSystemEntity>> reviveEntities =
         new ConvertElements<String, FileSystemEntity>(reviveEntity);
+    Converter<List<String>, Stream<FileSystemEntity>> reviveEntitiesAsStream =
+        reviveEntities
+            .fuse<Stream<FileSystemEntity>>(const ToStream<FileSystemEntity>());
 
     methods.addAll(<Symbol, Converter<dynamic, dynamic>>{
       #rename: reviveFutureDirectory,
@@ -34,7 +37,7 @@ class ReplayDirectory extends ReplayFileSystemEntity implements Directory {
       #createSync: const Passthrough<Null>(),
       #createTemp: reviveFutureDirectory,
       #createTempSync: reviveDirectory,
-      #list: reviveEntities.fuse(const ToStream<FileSystemEntity>()),
+      #list: reviveEntitiesAsStream,
       #listSync: reviveEntities,
       #childDirectory: reviveDirectory,
       #childFile: new ReviveFile(fileSystem),

--- a/lib/src/backends/record_replay/replay_file_system_entity.dart
+++ b/lib/src/backends/record_replay/replay_file_system_entity.dart
@@ -23,13 +23,15 @@ abstract class ReplayFileSystemEntity extends Object
             FileSystemEventCodec.deserialize);
     Converter<List<Map<String, Object>>, Stream<FileSystemEvent>>
         toEventStream = toEvents.fuse(const ToStream<FileSystemEvent>());
+    Converter<Map<String, Object>, Future<FileStat>> reviveFileStatFuture =
+        FileStatCodec.deserialize.fuse(const ToFuture<FileStat>());
 
     methods.addAll(<Symbol, Converter<dynamic, dynamic>>{
       #exists: const ToFuture<bool>(),
       #existsSync: const Passthrough<bool>(),
       #resolveSymbolicLinks: const ToFuture<String>(),
       #resolveSymbolicLinksSync: const Passthrough<String>(),
-      #stat: FileStatCodec.deserialize.fuse(const ToFuture<FileStat>()),
+      #stat: reviveFileStatFuture,
       #statSync: FileStatCodec.deserialize,
       #deleteSync: const Passthrough<Null>(),
       #watch: toEventStream,

--- a/lib/src/backends/record_replay/replay_io_sink.dart
+++ b/lib/src/backends/record_replay/replay_io_sink.dart
@@ -33,7 +33,7 @@ class ReplayIOSink extends ReplayProxyMixin implements IOSink {
     properties.addAll(<Symbol, Converter<dynamic, dynamic>>{
       #encoding: EncodingCodec.deserialize,
       const Symbol('encoding='): const Passthrough<Null>(),
-      #done: const Passthrough<dynamic>().fuse(const ToFuture<dynamic>()),
+      #done: const ToFuture<dynamic>(),
     });
   }
 
@@ -48,7 +48,7 @@ class ReplayIOSink extends ReplayProxyMixin implements IOSink {
     if (invocation.memberName == #addStream) {
       Stream<List<int>> stream = invocation.positionalArguments.first;
       Future<dynamic> future = result;
-      return future.then((_) => stream.drain());
+      return future.then<void>(stream.drain);
     }
     return result;
   }

--- a/lib/src/backends/record_replay/replay_link.dart
+++ b/lib/src/backends/record_replay/replay_link.dart
@@ -29,7 +29,7 @@ class ReplayLink extends ReplayFileSystemEntity implements Link {
       #createSync: const Passthrough<Null>(),
       #update: reviveLinkAsFuture,
       #updateSync: const Passthrough<Null>(),
-      #target: const Passthrough<String>().fuse(const ToFuture<String>()),
+      #target: const ToFuture<String>(),
       #targetSync: const Passthrough<String>(),
     });
 

--- a/lib/src/backends/record_replay/result_reference.dart
+++ b/lib/src/backends/record_replay/result_reference.dart
@@ -89,9 +89,8 @@ class FutureReference<T> extends ResultReference<Future<T>> {
   @override
   T get recordedValue => _value;
 
-  // TODO(tvolkert): remove `as Future<Null>` once Dart 1.22 is in stable
   @override
-  Future<Null> get complete => value.catchError((_) {}) as Future<Null>;
+  Future<Null> get complete => value.catchError((dynamic _) {});
 }
 
 /// Wraps a stream result.
@@ -159,5 +158,5 @@ class StreamReference<T> extends ResultReference<Stream<T>> {
   List<T> get recordedValue => _data;
 
   @override
-  Future<Null> get complete => _completer.future.catchError((_) {});
+  Future<Null> get complete => _completer.future.catchError((dynamic _) {});
 }

--- a/lib/src/forwarding.dart
+++ b/lib/src/forwarding.dart
@@ -2,18 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library file.src.forwarding;
-
-import 'dart:async';
-import 'dart:convert';
-
-import 'package:file/src/io.dart' as io;
-import 'package:file/file.dart';
-import 'package:meta/meta.dart';
-import 'package:path/path.dart' as p;
-
-part 'forwarding/forwarding_directory.dart';
-part 'forwarding/forwarding_file.dart';
-part 'forwarding/forwarding_file_system.dart';
-part 'forwarding/forwarding_file_system_entity.dart';
-part 'forwarding/forwarding_link.dart';
+export 'forwarding/forwarding_directory.dart';
+export 'forwarding/forwarding_file.dart';
+export 'forwarding/forwarding_file_system.dart';
+export 'forwarding/forwarding_file_system_entity.dart';
+export 'forwarding/forwarding_link.dart';

--- a/lib/src/forwarding/forwarding_directory.dart
+++ b/lib/src/forwarding/forwarding_directory.dart
@@ -2,7 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of file.src.forwarding;
+import 'dart:async';
+
+import 'package:file/src/io.dart' as io;
+import 'package:file/file.dart';
 
 /// A directory that forwards all methods and properties to a delegate.
 abstract class ForwardingDirectory<T extends Directory>

--- a/lib/src/forwarding/forwarding_file.dart
+++ b/lib/src/forwarding/forwarding_file.dart
@@ -2,7 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of file.src.forwarding;
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:file/src/io.dart' as io;
+import 'package:file/file.dart';
 
 /// A file that forwards all methods and properties to a delegate.
 abstract class ForwardingFile extends ForwardingFileSystemEntity<File, io.File>
@@ -73,7 +77,7 @@ abstract class ForwardingFile extends ForwardingFileSystemEntity<File, io.File>
   @override
   IOSink openWrite({
     FileMode mode: FileMode.WRITE,
-    Encoding encoding: UTF8,
+    Encoding encoding: utf8,
   }) =>
       delegate.openWrite(mode: mode, encoding: encoding);
 
@@ -84,19 +88,19 @@ abstract class ForwardingFile extends ForwardingFileSystemEntity<File, io.File>
   List<int> readAsBytesSync() => delegate.readAsBytesSync();
 
   @override
-  Future<String> readAsString({Encoding encoding: UTF8}) =>
+  Future<String> readAsString({Encoding encoding: utf8}) =>
       delegate.readAsString(encoding: encoding);
 
   @override
-  String readAsStringSync({Encoding encoding: UTF8}) =>
+  String readAsStringSync({Encoding encoding: utf8}) =>
       delegate.readAsStringSync(encoding: encoding);
 
   @override
-  Future<List<String>> readAsLines({Encoding encoding: UTF8}) =>
+  Future<List<String>> readAsLines({Encoding encoding: utf8}) =>
       delegate.readAsLines(encoding: encoding);
 
   @override
-  List<String> readAsLinesSync({Encoding encoding: UTF8}) =>
+  List<String> readAsLinesSync({Encoding encoding: utf8}) =>
       delegate.readAsLinesSync(encoding: encoding);
 
   @override
@@ -123,7 +127,7 @@ abstract class ForwardingFile extends ForwardingFileSystemEntity<File, io.File>
   Future<File> writeAsString(
     String contents, {
     FileMode mode: FileMode.WRITE,
-    Encoding encoding: UTF8,
+    Encoding encoding: utf8,
     bool flush: false,
   }) async =>
       wrap(await delegate.writeAsString(
@@ -137,7 +141,7 @@ abstract class ForwardingFile extends ForwardingFileSystemEntity<File, io.File>
   void writeAsStringSync(
     String contents, {
     FileMode mode: FileMode.WRITE,
-    Encoding encoding: UTF8,
+    Encoding encoding: utf8,
     bool flush: false,
   }) =>
       delegate.writeAsStringSync(

--- a/lib/src/forwarding/forwarding_file_system.dart
+++ b/lib/src/forwarding/forwarding_file_system.dart
@@ -2,7 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of file.src.forwarding;
+import 'dart:async';
+
+import 'package:file/src/io.dart' as io;
+import 'package:file/file.dart';
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
 
 /// A file system that forwards all methods and properties to a delegate.
 abstract class ForwardingFileSystem extends FileSystem {

--- a/lib/src/forwarding/forwarding_file_system_entity.dart
+++ b/lib/src/forwarding/forwarding_file_system_entity.dart
@@ -2,7 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of file.src.forwarding;
+import 'dart:async';
+
+import 'package:file/src/io.dart' as io;
+import 'package:file/file.dart';
+import 'package:meta/meta.dart';
 
 /// A file system entity that forwards all methods and properties to a delegate.
 abstract class ForwardingFileSystemEntity<T extends FileSystemEntity,

--- a/lib/src/forwarding/forwarding_link.dart
+++ b/lib/src/forwarding/forwarding_link.dart
@@ -2,7 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-part of file.src.forwarding;
+import 'dart:async';
+
+import 'package:file/src/io.dart' as io;
+import 'package:file/file.dart';
 
 /// A link that forwards all methods and properties to a delegate.
 abstract class ForwardingLink extends ForwardingFileSystemEntity<Link, io.Link>

--- a/lib/src/interface/file.dart
+++ b/lib/src/interface/file.dart
@@ -36,6 +36,6 @@ abstract class File implements FileSystemEntity, io.File {
   @override
   Future<File> writeAsString(String contents,
       {io.FileMode mode: io.FileMode.WRITE,
-      Encoding encoding: UTF8,
+      Encoding encoding: utf8,
       bool flush: false});
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 4.0.0
+version: 4.0.1
 authors:
 - Matan Lurey <matanl@google.com>
 - Yegor Jbanov <yjbanov@google.com>
@@ -9,11 +9,11 @@ homepage: https://github.com/google/file.dart
 
 dependencies:
   intl: '>=0.14.0 <0.16.0'
-  meta: ^1.0.4
-  path: ^1.4.0
+  meta: ^1.1.2
+  path: ^1.5.1
 
 dev_dependencies:
-  test: ^0.12.18
+  test: ^0.12.33
 
 environment:
   sdk: '>=2.0.0-dev.28.0 <2.0.0'

--- a/test/common_tests.dart
+++ b/test/common_tests.dart
@@ -65,7 +65,7 @@ void runCommonTests(
 
     List<String> stack = <String>[];
 
-    void skipIfNecessary(String description, callback()) {
+    void skipIfNecessary(String description, void callback()) {
       stack.add(description);
       bool matchesCurrentFrame(String input) =>
           new RegExp('^$input\$').hasMatch(stack.join(' > '));
@@ -83,11 +83,11 @@ void runCommonTests(
       root = null;
     });
 
-    void setUp(callback()) {
+    void setUp(FutureOr<void> callback()) {
       testpkg.setUp(replay == null ? callback : () => setUps.add(callback));
     }
 
-    void tearDown(callback()) {
+    void tearDown(FutureOr<void> callback()) {
       if (replay == null) {
         testpkg.tearDown(callback);
       } else {
@@ -95,10 +95,11 @@ void runCommonTests(
       }
     }
 
-    void group(String description, body()) =>
+    void group(String description, void body()) =>
         skipIfNecessary(description, () => testpkg.group(description, body));
 
-    void test(String description, body()) => skipIfNecessary(description, () {
+    void test(String description, FutureOr<void> body()) =>
+        skipIfNecessary(description, () {
           if (replay == null) {
             testpkg.test(description, body);
           } else {
@@ -1768,20 +1769,20 @@ void runCommonTests(
                 });
 
                 test('readByte', () {
-                  expect(UTF8.decode(<int>[raf.readByteSync()]), 'p');
+                  expect(utf8.decode(<int>[raf.readByteSync()]), 'p');
                 });
 
                 test('read', () {
                   List<int> bytes = raf.readSync(1024);
                   expect(bytes.length, 21);
-                  expect(UTF8.decode(bytes), 'pre-existing content\n');
+                  expect(utf8.decode(bytes), 'pre-existing content\n');
                 });
 
                 test('readIntoWithBufferLargerThanContent', () {
                   List<int> buffer = new List<int>(1024);
                   int numRead = raf.readIntoSync(buffer);
                   expect(numRead, 21);
-                  expect(UTF8.decode(buffer.sublist(0, 21)),
+                  expect(utf8.decode(buffer.sublist(0, 21)),
                       'pre-existing content\n');
                 });
 
@@ -1789,21 +1790,21 @@ void runCommonTests(
                   List<int> buffer = new List<int>(10);
                   int numRead = raf.readIntoSync(buffer);
                   expect(numRead, 10);
-                  expect(UTF8.decode(buffer), 'pre-existi');
+                  expect(utf8.decode(buffer), 'pre-existi');
                 });
 
                 test('readIntoWithStart', () {
                   List<int> buffer = new List<int>(10);
                   int numRead = raf.readIntoSync(buffer, 2);
                   expect(numRead, 8);
-                  expect(UTF8.decode(buffer.sublist(2)), 'pre-exis');
+                  expect(utf8.decode(buffer.sublist(2)), 'pre-exis');
                 });
 
                 test('readIntoWithStartAndEnd', () {
                   List<int> buffer = new List<int>(10);
                   int numRead = raf.readIntoSync(buffer, 2, 5);
                   expect(numRead, 3);
-                  expect(UTF8.decode(buffer.sublist(2, 5)), 'pre');
+                  expect(utf8.decode(buffer.sublist(2, 5)), 'pre');
                 });
               });
             }
@@ -1841,7 +1842,7 @@ void runCommonTests(
               });
 
               test('writeByte', () {
-                raf.writeByteSync(UTF8.encode('A').first);
+                raf.writeByteSync(utf8.encode('A').first);
                 raf.flushSync();
                 if (mode == FileMode.WRITE || mode == FileMode.WRITE_ONLY) {
                   expect(f.readAsStringSync(), 'A');
@@ -1851,7 +1852,7 @@ void runCommonTests(
               });
 
               test('writeFrom', () {
-                raf.writeFromSync(UTF8.encode('Hello world'));
+                raf.writeFromSync(utf8.encode('Hello world'));
                 raf.flushSync();
                 if (mode == FileMode.WRITE || mode == FileMode.WRITE_ONLY) {
                   expect(f.readAsStringSync(), 'Hello world');
@@ -1862,7 +1863,7 @@ void runCommonTests(
               });
 
               test('writeFromWithStart', () {
-                raf.writeFromSync(UTF8.encode('Hello world'), 2);
+                raf.writeFromSync(utf8.encode('Hello world'), 2);
                 raf.flushSync();
                 if (mode == FileMode.WRITE || mode == FileMode.WRITE_ONLY) {
                   expect(f.readAsStringSync(), 'llo world');
@@ -1873,7 +1874,7 @@ void runCommonTests(
               });
 
               test('writeFromWithStartAndEnd', () {
-                raf.writeFromSync(UTF8.encode('Hello world'), 2, 5);
+                raf.writeFromSync(utf8.encode('Hello world'), 2, 5);
                 raf.flushSync();
                 if (mode == FileMode.WRITE || mode == FileMode.WRITE_ONLY) {
                   expect(f.readAsStringSync(), 'llo');
@@ -1922,7 +1923,7 @@ void runCommonTests(
 
                 test('affectsRead', () {
                   raf.setPositionSync(5);
-                  expect(UTF8.decode(raf.readSync(5)), 'xisti');
+                  expect(utf8.decode(raf.readSync(5)), 'xisti');
                 });
               }
 
@@ -1952,9 +1953,9 @@ void runCommonTests(
                   raf.flushSync();
                   List<int> bytes = f.readAsBytesSync();
                   expect(bytes.length, 36);
-                  expect(UTF8.decode(bytes.sublist(0, 21)),
+                  expect(utf8.decode(bytes.sublist(0, 21)),
                       'pre-existing content\n');
-                  expect(UTF8.decode(bytes.sublist(32, 36)), 'here');
+                  expect(utf8.decode(bytes.sublist(32, 36)), 'here');
                   expect(bytes.sublist(21, 32), everyElement(0));
                 });
               }
@@ -2006,7 +2007,7 @@ void runCommonTests(
                   raf.flushSync();
                   List<int> bytes = f.readAsBytesSync();
                   expect(bytes.length, 32);
-                  expect(UTF8.decode(bytes.sublist(0, 21)),
+                  expect(utf8.decode(bytes.sublist(0, 21)),
                       'pre-existing content\n');
                   expect(bytes.sublist(21, 32), everyElement(0));
                 });
@@ -2032,7 +2033,8 @@ void runCommonTests(
       group('openRead', () {
         test('throwsIfDoesntExist', () {
           Stream<List<int>> stream = fs.file(ns('/foo')).openRead();
-          expect(stream.drain(), throwsFileSystemException(ErrorCodes.ENOENT));
+          expect(stream.drain<void>(),
+              throwsFileSystemException(ErrorCodes.ENOENT));
         });
 
         test('succeedsIfExistsAsFile', () async {
@@ -2041,13 +2043,14 @@ void runCommonTests(
           Stream<List<int>> stream = f.openRead();
           List<List<int>> data = await stream.toList();
           expect(data, hasLength(1));
-          expect(UTF8.decode(data[0]), 'Hello world');
+          expect(utf8.decode(data[0]), 'Hello world');
         });
 
         test('throwsIfExistsAsDirectory', () {
           fs.directory(ns('/foo')).createSync();
           Stream<List<int>> stream = fs.file(ns('/foo')).openRead();
-          expect(stream.drain(), throwsFileSystemException(ErrorCodes.EISDIR));
+          expect(stream.drain<void>(),
+              throwsFileSystemException(ErrorCodes.EISDIR));
         });
 
         test('succeedsIfExistsAsLinkToFile', () async {
@@ -2057,7 +2060,7 @@ void runCommonTests(
           Stream<List<int>> stream = fs.file(ns('/bar')).openRead();
           List<List<int>> data = await stream.toList();
           expect(data, hasLength(1));
-          expect(UTF8.decode(data[0]), 'Hello world');
+          expect(utf8.decode(data[0]), 'Hello world');
         });
 
         test('respectsStartAndEndParameters', () async {
@@ -2066,17 +2069,17 @@ void runCommonTests(
           Stream<List<int>> stream = f.openRead(2);
           List<List<int>> data = await stream.toList();
           expect(data, hasLength(1));
-          expect(UTF8.decode(data[0]), 'llo world');
+          expect(utf8.decode(data[0]), 'llo world');
           stream = f.openRead(2, 5);
           data = await stream.toList();
           expect(data, hasLength(1));
-          expect(UTF8.decode(data[0]), 'llo');
+          expect(utf8.decode(data[0]), 'llo');
         });
 
         test('throwsIfStartParameterIsNegative', () async {
           File f = fs.file(ns('/foo'))..createSync();
           Stream<List<int>> stream = f.openRead(-2);
-          expect(stream.drain(), throwsRangeError);
+          expect(stream.drain<void>(), throwsRangeError);
         });
 
         test('stopsAtEndOfFileIfEndParameterIsPastEndOfFile', () async {
@@ -2085,7 +2088,7 @@ void runCommonTests(
           Stream<List<int>> stream = f.openRead(2, 1024);
           List<List<int>> data = await stream.toList();
           expect(data, hasLength(1));
-          expect(UTF8.decode(data[0]), 'llo world');
+          expect(utf8.decode(data[0]), 'llo world');
         });
 
         test('providesSingleSubscriptionStream', () async {
@@ -2093,7 +2096,7 @@ void runCommonTests(
           f.writeAsStringSync('Hello world', flush: true);
           Stream<List<int>> stream = f.openRead();
           expect(stream.isBroadcast, isFalse);
-          await stream.drain();
+          await stream.drain<void>();
         });
       });
 
@@ -2194,9 +2197,9 @@ void runCommonTests(
           });
 
           test('allowsChangingEncoding', () async {
-            sink.encoding = LATIN1;
+            sink.encoding = latin1;
             sink.write('ÿ');
-            sink.encoding = UTF8;
+            sink.encoding = utf8;
             sink.write('ÿ');
             await sink.flush();
             expect(await f.readAsBytes(), <int>[255, 195, 191]);
@@ -2232,23 +2235,27 @@ void runCommonTests(
             expect(await f.readAsString(), 'Hello world\n');
           });
 
+          // TODO(tvolkert): Fix and re-enable: http://dartbug.com/29554
+          /*
           test('ignoresDataWrittenAfterClose', () async {
             sink.write('Before close');
             await closeSink();
             sink.write('After close');
             expect(await f.readAsString(), 'Before close');
           });
+          */
 
           test('ignoresCloseAfterAlreadyClosed', () async {
             sink.write('Hello world');
             Future<dynamic> f1 = closeSink();
             Future<dynamic> f2 = closeSink();
-            await Future.wait(<Future<dynamic>>[f1, f2]);
+            await Future.wait<dynamic>(<Future<dynamic>>[f1, f2]);
           });
 
           test('returnsAccurateDoneFuture', () async {
             bool done = false;
-            sink.done.then((_) => done = true); // ignore: unawaited_futures
+            sink.done
+                .then((dynamic _) => done = true); // ignore: unawaited_futures
             expect(done, isFalse);
             sink.write('foo');
             expect(done, isFalse);

--- a/test/recording_test.dart
+++ b/test/recording_test.dart
@@ -194,7 +194,7 @@ void main() {
         rc.basicMethod('bar', namedArg: 'baz');
         await rc.futureProperty;
         await rc.futureMethod('qux', namedArg: 'quz');
-        await rc.streamMethod('quux', namedArg: 'quuz').drain();
+        await rc.streamMethod('quux', namedArg: 'quuz').drain<void>();
         List<Map<String, dynamic>> manifest = await encode(recording.events);
         expect(manifest[0], <String, dynamic>{
           'type': 'set',
@@ -562,7 +562,7 @@ void main() {
           await delegate.directory('/bar').create();
           await delegate.file('/baz').create();
           Stream<FileSystemEntity> stream = fs.directory('/').list();
-          await stream.drain();
+          await stream.drain<void>();
           expect(
             recording.events,
             contains(invokesMethod('list')
@@ -605,7 +605,7 @@ void main() {
           String content = 'Hello\nWorld';
           await delegate.file('/foo').writeAsString(content, flush: true);
           Stream<List<int>> stream = fs.file('/foo').openRead();
-          await stream.drain();
+          await stream.drain<void>();
           expect(
               recording.events,
               contains(invokesMethod('openRead')
@@ -693,13 +693,13 @@ void main() {
           String content = 'Hello\nWorld';
           await delegate
               .file('/foo')
-              .writeAsString(content, encoding: LATIN1, flush: true);
-          await fs.file('/foo').readAsString(encoding: LATIN1);
+              .writeAsString(content, encoding: latin1, flush: true);
+          await fs.file('/foo').readAsString(encoding: latin1);
           expect(
               recording.events,
               contains(invokesMethod('readAsString')
                   .on(isFile)
-                  .withNamedArgument('encoding', LATIN1)
+                  .withNamedArgument('encoding', latin1)
                   .withResult(content)));
           await recording.flush();
           List<Map<String, dynamic>> manifest = _loadManifest(recording);
@@ -728,13 +728,13 @@ void main() {
           String content = 'Hello\nWorld';
           await delegate
               .file('/foo')
-              .writeAsString(content, encoding: LATIN1, flush: true);
-          fs.file('/foo').readAsStringSync(encoding: LATIN1);
+              .writeAsString(content, encoding: latin1, flush: true);
+          fs.file('/foo').readAsStringSync(encoding: latin1);
           expect(
               recording.events,
               contains(invokesMethod('readAsStringSync')
                   .on(isFile)
-                  .withNamedArgument('encoding', LATIN1)
+                  .withNamedArgument('encoding', latin1)
                   .withResult(content)));
           await recording.flush();
           List<Map<String, dynamic>> manifest = _loadManifest(recording);
@@ -888,8 +888,7 @@ class _RecordingClass extends Object
     this.delegate,
     this.stopwatch,
     Directory destination,
-  })
-      : recording = new MutableRecording(destination) {
+  }) : recording = new MutableRecording(destination) {
     methods.addAll(<Symbol, Function>{
       #basicMethod: delegate.basicMethod,
       #futureMethod: delegate.futureMethod,


### PR DESCRIPTION
* Fix/update analysis options
* Fix some linter errors
* Run dartfmt
* Fix some Dart 2 strong-mode type checks
* Remove usage of "part" and "part of" in the forwarding, memory, and local backends.
* Fix AppVeyor and Travis scripts to work only for Dart 2
* Comment out test that's causing problems with newer SDKs
