### PR TITLE
Fix runtime errors in recording_test

### DIFF
--- a/packages/file/lib/src/backends/record_replay/recording_proxy_mixin.dart
+++ b/packages/file/lib/src/backends/record_replay/recording_proxy_mixin.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'package:file/file.dart';
+import 'package:file/src/backends/memory/node.dart';
 
 import 'package:meta/meta.dart';
 
@@ -137,10 +139,37 @@ abstract class RecordingProxyMixin implements ProxyObject, ReplayAware {
 
     // Wrap Future and Stream results so that we record their values as they
     // become available.
-    if (value is Stream) {
-      value = new StreamReference<dynamic>(value);
+    // We have to instantiate the correct type of StreamReference or
+    // FutureReference, so that types are not lost when we unwrap the references
+    // afterward.
+    if (value is Stream<FileSystemEntity>) {
+      value = new StreamReference<FileSystemEntity>(value);
+    } else if (value is Stream<String>) {
+      value = new StreamReference<String>(value);
+    } else if (value is Stream) {
+      throw new UnimplementedError(
+          'Cannot record method with return type ${value.runtimeType}');
+    } else if (value is Future<bool>) {
+      value = new FutureReference<bool>(value);
+    } else if (value is Future<Directory>) {
+      value = new FutureReference<Directory>(value);
+    } else if (value is Future<File>) {
+      value = new FutureReference<File>(value);
+    } else if (value is Future<FileNode>) {
+      value = new FutureReference<FileNode>(value);
+    } else if (value is Future<FileStat>) {
+      value = new FutureReference<FileStat>(value);
+    } else if (value is Future<Link>) {
+      value = new FutureReference<Link>(value);
+    } else if (value is Future<FileSystemEntity>) {
+      value = new FutureReference<FileSystemEntity>(value);
+    } else if (value is Future<FileSystemEntityType>) {
+      value = new FutureReference<FileSystemEntityType>(value);
+    } else if (value is Future<String>) {
+      value = new FutureReference<String>(value);
     } else if (value is Future) {
-      value = new FutureReference<dynamic>(value);
+      throw new UnimplementedError(
+          'Cannot record method with return type ${value.runtimeType}');
     }
 
     // Record the invocation event associated with this invocation.

--- a/packages/file/lib/src/backends/record_replay/recording_proxy_mixin.dart
+++ b/packages/file/lib/src/backends/record_replay/recording_proxy_mixin.dart
@@ -142,13 +142,19 @@ abstract class RecordingProxyMixin implements ProxyObject, ReplayAware {
     // We have to instantiate the correct type of StreamReference or
     // FutureReference, so that types are not lost when we unwrap the references
     // afterward.
-    if (value is Stream<FileSystemEntity>) {
+    if (value is Stream<dynamic>) {
+      // This one is here for Dart 1 runtime mode.
+      value = new StreamReference<dynamic>(value);
+    } else if (value is Stream<FileSystemEntity>) {
       value = new StreamReference<FileSystemEntity>(value);
     } else if (value is Stream<String>) {
       value = new StreamReference<String>(value);
     } else if (value is Stream) {
       throw new UnimplementedError(
           'Cannot record method with return type ${value.runtimeType}');
+    } else if (value is Future<dynamic>) {
+      // This one is here for Dart 1 runtime mode.
+      value = new FutureReference<dynamic>(value);
     } else if (value is Future<bool>) {
       value = new FutureReference<bool>(value);
     } else if (value is Future<Directory>) {

--- a/packages/file/lib/src/backends/record_replay/result_reference.dart
+++ b/packages/file/lib/src/backends/record_replay/result_reference.dart
@@ -57,7 +57,7 @@ abstract class ResultReference<T> {
   /// completed. If [value] is a [Stream], this future will complete when the
   /// stream sends a "done" event. If value is neither a future nor a stream,
   /// this future will complete immediately.
-  Future<Null> get complete => new Future<Null>.value();
+  Future<void> get complete => new Future<void>.value();
 }
 
 /// Wraps a future result.
@@ -90,7 +90,7 @@ class FutureReference<T> extends ResultReference<Future<T>> {
   T get recordedValue => _value;
 
   @override
-  Future<Null> get complete => value.catchError((dynamic _) {});
+  Future<void> get complete => value.catchError((dynamic _) {});
 }
 
 /// Wraps a stream result.

--- a/packages/file/test/recording_test.dart
+++ b/packages/file/test/recording_test.dart
@@ -196,7 +196,8 @@ void main() {
         await rc.futureProperty;
         await rc.futureMethod('qux', namedArg: 'quz');
         await rc.streamMethod('quux', namedArg: 'quuz').drain<void>();
-        List<Map<String, dynamic>> manifest = await encode(recording.events);
+        List<Map<String, dynamic>> manifest =
+            await encode(recording.events).retype<Map<String, dynamic>>();
         expect(manifest[0], <String, dynamic>{
           'type': 'set',
           'property': 'basicProperty=',
@@ -834,7 +835,9 @@ List<Map<String, dynamic>> _loadManifest(LiveRecording recording) {
   List<FileSystemEntity> files = recording.destination.listSync();
   File manifestFile = files.singleWhere(
       (FileSystemEntity entity) => entity.basename == kManifestName);
-  return new JsonDecoder().convert(manifestFile.readAsStringSync());
+  return new JsonDecoder()
+      .convert(manifestFile.readAsStringSync())
+      .retype<Map<String, dynamic>>();
 }
 
 File _getRecordingFile(LiveRecording recording, String manifestReference) {


### PR DESCRIPTION
Fixes #84 

There were a number of runtime failures. Some were simple. The ones that involved noSuchMethod in `recording_proxy_mixin.dart` were not simple. Basically, because of how the `noSuchMethod` is implemented, in terms of Futures and Streams, and how FutureReference.value and StreamReference.value work, types were being lost. If `value`  was a `Future<Directory>`, as returned by `Function.apply`, then `result` was inevitably `Future<dynamic>` by the end of `noSuchMethod`. ☹️ 

Tested with `dart --preview-dart-2 test/recording_test.dart` and `dart test/recording_test.dart`.