### PR TITLE
Fix Dart 2 errors for Future based directory operations.

### DIFF
--- a/packages/file/lib/src/backends/chroot/chroot_directory.dart
+++ b/packages/file/lib/src/backends/chroot/chroot_directory.dart
@@ -173,4 +173,12 @@ class _ChrootDirectory extends _ChrootFileSystemEntity<Directory, io.Directory>
 
   @override
   String toString() => "ChrootDirectory: '$path'";
+
+  @override
+  Future<_ChrootDirectory> delete({bool recursive: false}) async =>
+      wrap(await delegate.delete(recursive: recursive));
+
+  @override
+  Future<_ChrootDirectory> createTemp([String prefix]) async =>
+      wrap(await delegate.createTemp(prefix));
 }

--- a/packages/file/lib/src/backends/local/local_directory.dart
+++ b/packages/file/lib/src/backends/local/local_directory.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:file/src/common.dart' as common;
 import 'package:file/src/forwarding.dart';
 import 'package:file/src/io.dart' as io;
@@ -18,4 +20,20 @@ class LocalDirectory extends LocalFileSystemEntity<LocalDirectory, io.Directory>
 
   @override
   String toString() => "LocalDirectory: '$path'";
+
+  @override
+  Future<LocalDirectory> create({bool recursive: false}) async =>
+      wrap(await delegate.create(recursive: recursive));
+
+  @override
+  Future<LocalDirectory> delete({bool recursive: false}) async =>
+      wrap(await delegate.delete(recursive: recursive));
+
+  @override
+  Future<LocalDirectory> rename(String newPath) async =>
+      wrap(await delegate.rename(newPath));
+
+  @override
+  Future<LocalDirectory> createTemp([String prefix]) async =>
+      wrap(await delegate.createTemp(prefix));
 }


### PR DESCRIPTION
Dart 2 is not loving the very complicated inheritance and mixin pattern we have for these classes. Explicitly overriding the Future returning methods to specify the types fix all the tests but is obviously a bandaid.