### PR TITLE
Use Linux error codes as fallback when OS error codes are not defined

### DIFF
--- a/packages/file/lib/src/interface/error_codes.dart
+++ b/packages/file/lib/src/interface/error_codes.dart
@@ -168,7 +168,7 @@ class ErrorCodes {
   static int get EXDEV => _platform((_Codes codes) => codes.exdev);
 
   static int _platform(int getCode(_Codes codes)) {
-    _Codes codes = _platforms[operatingSystem];
+    _Codes codes = _platforms[operatingSystem] ?? _platforms['linux'];
     return getCode(codes);
   }
 }


### PR DESCRIPTION
When using this library in an operating system that is not Linux, MacOS or Windows (such as Android or iOS), there is a crash when getting a file system error code.

A possible solution is to use Linux as a fallback whenever the OS doesn't have its own error code defined.