### PR TITLE
bump Dart SDK constraint

### DIFF
--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 5.0.1
+version: 5.0.2
 authors:
 - Matan Lurey <matanl@google.com>
 - Yegor Jbanov <yjbanov@google.com>
@@ -17,4 +17,4 @@ dev_dependencies:
   file_testing: '>=2.0.0 <3.0.0'
 
 environment:
-  sdk: '>=2.0.0-dev.54.0 <2.0.0'
+  sdk: '>=2.0.0-dev.54.0 <3.0.0'


### PR DESCRIPTION
Should address build failures due to unsolvable constraints.

```
Package dart_coveralls is currently active at version 0.6.0+3.
Resolving dependencies...
The current Dart SDK version is 2.1.0-dev.0.0.
Because dart_coveralls <=0.6.0+1 requires SDK version <2.0.0 or >=2.0.0-dev.55.0 <2.0.0 and dart_coveralls >=0.6.0+2 depends on file ^5.0.0, every version of dart_coveralls requires file ^5.0.0.
So, because file >=0.1.0 requires SDK version <2.0.0-∞ and pub global activate depends on dart_coveralls any, version solving failed.
```

https://travis-ci.org/dart-lang/linter/jobs/414234035

/cc @tvolkert @matanlurey @srawlins 

