### PR TITLE
Add tests that fail because of slash directions

### DIFF
--- a/packages/file/test/common_tests.dart
+++ b/packages/file/test/common_tests.dart
@@ -173,6 +173,13 @@ void runCommonTests(
         test('disallowsOtherArgumentType', () {
           expect(() => fs.directory(123), throwsArgumentError);
         });
+
+        // Fails due to
+        // https://github.com/google/file.dart/issues/112
+        test('considersBothSlashesEquivalent', () {
+          fs.directory(r'foo\bar_dir').createSync(recursive: true);
+          expect(fs.directory(r'foo/bar_dir'), exists);
+        });
       });
 
       group('file', () {
@@ -196,6 +203,13 @@ void runCommonTests(
 
         test('disallowsOtherArgumentType', () {
           expect(() => fs.file(123), throwsArgumentError);
+        });
+
+        // Fails due to
+        // https://github.com/google/file.dart/issues/112
+        test('considersBothSlashesEquivalent', () {
+          fs.file(r'foo\bar_file').createSync(recursive: true);
+          expect(fs.file(r'foo/bar_file'), exists);
         });
       });
 


### PR DESCRIPTION
Failing tests due to #112.

I couldn't figure out how to mark them as failing (or skip) since there's no `@failingTest` and the `test` function seems custom.

@tvolkert 