### PR TITLE
Rework mixins to avoid extending non-Object.

### DIFF
--- a/packages/file/lib/src/forwarding/forwarding_directory.dart
+++ b/packages/file/lib/src/forwarding/forwarding_directory.dart
@@ -9,7 +9,7 @@ import 'package:file/file.dart';
 
 /// A directory that forwards all methods and properties to a delegate.
 abstract class ForwardingDirectory<T extends Directory>
-    extends ForwardingFileSystemEntity<T, io.Directory> implements Directory {
+    implements ForwardingFileSystemEntity<T, io.Directory>, Directory {
   @override
   T wrap(io.Directory delegate) => wrapDirectory(delegate);
 

--- a/packages/file/lib/src/forwarding/forwarding_file.dart
+++ b/packages/file/lib/src/forwarding/forwarding_file.dart
@@ -9,8 +9,8 @@ import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 
 /// A file that forwards all methods and properties to a delegate.
-abstract class ForwardingFile extends ForwardingFileSystemEntity<File, io.File>
-    implements File {
+abstract class ForwardingFile
+    implements ForwardingFileSystemEntity<File, io.File>, File {
   @override
   ForwardingFile wrap(io.File delegate) => wrapFile(delegate);
 

--- a/packages/file/lib/src/forwarding/forwarding_link.dart
+++ b/packages/file/lib/src/forwarding/forwarding_link.dart
@@ -8,8 +8,8 @@ import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 
 /// A link that forwards all methods and properties to a delegate.
-abstract class ForwardingLink extends ForwardingFileSystemEntity<Link, io.Link>
-    implements Link {
+abstract class ForwardingLink
+    implements ForwardingFileSystemEntity<Link, io.Link>, Link {
   @override
   ForwardingLink wrap(io.Link delegate) => wrapLink(delegate);
 


### PR DESCRIPTION
The ability for a class extending non-Object to be used as a mixin
will be removed from Dart in an upcoming release.  In general, code
taking advantage of this ability can be fixed in two ways:

- The class can be changed to use the new "mixin" syntax (see
  https://github.com/dart-lang/language/blob/master/working/0006.%20Superinvocations%20in%20mixins/0007.%20Mixin%20declarations/lrhn-strawman.md).

- If the class contains no references to "super", the base class can
  simply be moved into the "implements" clause (e.g. "abstract class M
  extends A implements B {...}" can be changed to "abstract class M
  implements A, B {...}"

This CL adopts the second strategy, since it's feasible (the classes
in question do not use "super") and since it's backwards compatible to
older versions of Dart.