### PR TITLE
Switch to new-style mixins so that super.noSuchMethod can be called.

### DIFF
--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 5.0.7
+
+* Dart 2 fixes for `RecordingProxyMixin` and `ReplayProxyMixin`.
+
 #### 5.0.6
 
 * Dart 2 fixes for `RecordingFile.open()`

--- a/packages/file/lib/src/backends/record_replay/recording_file_system_entity.dart
+++ b/packages/file/lib/src/backends/record_replay/recording_file_system_entity.dart
@@ -19,7 +19,7 @@ import 'recording_proxy_mixin.dart';
 /// [FileSystemEntity] implementation that records all invocation activity to
 /// its file system's recording.
 abstract class RecordingFileSystemEntity<T extends FileSystemEntity>
-    extends RecordingProxyMixin implements FileSystemEntity {
+    extends Object with RecordingProxyMixin implements FileSystemEntity {
   /// Creates a new `RecordingFileSystemEntity`.
   RecordingFileSystemEntity(this.fileSystem, this.delegate) {
     methods.addAll(<Symbol, Function>{

--- a/packages/file/lib/src/backends/record_replay/recording_proxy_mixin.dart
+++ b/packages/file/lib/src/backends/record_replay/recording_proxy_mixin.dart
@@ -63,7 +63,7 @@ import 'result_reference.dart';
 /// Methods that return [Stream]s will be recorded immediately, but their
 /// return values will be recorded as a [List] that will grow as the stream
 /// produces data.
-abstract class RecordingProxyMixin implements ProxyObject, ReplayAware {
+mixin RecordingProxyMixin on Object implements ProxyObject, ReplayAware {
   /// Maps method names to delegate functions.
   ///
   /// Invocations of methods listed in this map will be recorded after

--- a/packages/file/lib/src/backends/record_replay/replay_io_sink.dart
+++ b/packages/file/lib/src/backends/record_replay/replay_io_sink.dart
@@ -13,7 +13,7 @@ import 'replay_proxy_mixin.dart';
 
 /// [IOSink] implementation that replays all invocation activity from a prior
 /// recording.
-class ReplayIOSink extends ReplayProxyMixin implements IOSink {
+class ReplayIOSink extends Object with ReplayProxyMixin implements IOSink {
   final ReplayFileSystemImpl _fileSystem;
 
   /// Creates a new [ReplayIOSink].

--- a/packages/file/lib/src/backends/record_replay/replay_proxy_mixin.dart
+++ b/packages/file/lib/src/backends/record_replay/replay_proxy_mixin.dart
@@ -43,7 +43,7 @@ int _nextOrdinal = 0;
 ///       Foo sampleParent;
 ///     }
 ///
-///     class ReplayFoo extends ReplayProxyMixin implements Foo {
+///     class ReplayFoo extends Object with ReplayProxyMixin implements Foo {
 ///       final List<Map<String, dynamic>> manifest;
 ///       final String identifier;
 ///
@@ -58,7 +58,7 @@ int _nextOrdinal = 0;
 ///         });
 ///       }
 ///     }
-abstract class ReplayProxyMixin implements ProxyObject, ReplayAware {
+mixin ReplayProxyMixin on Object implements ProxyObject, ReplayAware {
   /// Maps method names to [Converter]s that will revive result values.
   ///
   /// Invocations of methods listed in this map will be replayed by looking for

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 5.0.6
+version: 5.0.7
 authors:
 - Matan Lurey <matanl@google.com>
 - Yegor Jbanov <yjbanov@google.com>


### PR DESCRIPTION
The ability for a class used as a mixin to call super has been removed
from Dart, but due to an analyzer bug some usages slipped through the
cracks.  The analyzer bug has now been fixed, so we need a
corresponding fix to package:file.

The solution is to change the mixin classes to use the new "mixin"
syntax.