### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/packages/file/lib/src/forwarding/forwarding_file.dart
+++ b/packages/file/lib/src/forwarding/forwarding_file.dart
@@ -72,8 +72,10 @@ abstract class ForwardingFile
       delegate.openSync(mode: mode);
 
   @override
-  Stream<Uint8List> openRead([int start, int end]) =>
-      delegate.openRead(start, end).transform(const _ToUint8List());
+  Stream<Uint8List> openRead([int start, int end]) => delegate
+      .openRead(start, end)
+      .cast<List<int>>()
+      .transform(const _ToUint8List());
 
   @override
   IOSink openWrite({

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 5.0.8
+version: 5.0.8+1
 authors:
 - Matan Lurey <matanl@google.com>
 - Yegor Jbanov <yjbanov@google.com>


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900