### PR TITLE
use context.split instead of String.split in MemoryFileSystem.findNode

### DIFF
--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 5.1.1
+
+* Fixed a bug in `MemoryFileSystem` where file paths with forward slashes created with  `FileSystemStyle.windows` were incorrectly parsed.
+
 #### 5.1.0
 
 * Added a new `MemoryFileSystem` constructor to use a test clock

--- a/packages/file/lib/src/backends/memory/memory_file_system.dart
+++ b/packages/file/lib/src/backends/memory/memory_file_system.dart
@@ -214,8 +214,7 @@ class _MemoryFileSystem extends FileSystem
       reference ??= _current;
     }
 
-    List<String> parts = path.split(style.separator)
-      ..removeWhere(utils.isEmpty);
+    List<String> parts = _context.split(path);
     DirectoryNode directory = reference.directory;
     Node child = directory;
 

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 5.1.0
+version: 5.1.1
 authors:
 - Matan Lurey <matanl@google.com>
 - Yegor Jbanov <yjbanov@google.com>

--- a/packages/file/test/memory_test.dart
+++ b/packages/file/test/memory_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:file/memory.dart';
 import 'package:test/test.dart';
 
@@ -95,5 +97,18 @@ void main() {
         DateTime(2000, 1, 1, 0, 4)); // didn't touch it
     expect(
         fs.file('/test2.txt').statSync().modified, DateTime(2000, 1, 1, 0, 6));
+  });
+
+  test('Regression test for forward slash in windows fillesystem', () {
+    final MemoryFileSystem fs = MemoryFileSystem(style: FileSystemStyle.windows);
+    final File file = fs.file(r'C:\a\b\c/d.png');
+    file.createSync(recursive: true);
+    file.writeAsStringSync('hello');
+
+    expect(file.existsSync(), true);
+
+    file.deleteSync();
+
+    expect(file.existsSync(), false);
   });
 }


### PR DESCRIPTION
Fixes https://github.com/google/file.dart/issues/131

According to package:path, both `/` and `\` are valid separators for a windows filesystem. Thus when interpreting a path like `C:\a/b.dart`, the segments are ['a', 'b.dart']. This seems to be used by the entity and for file creation.

The findNode logic in the memory file system was using String.split, which interpreted the segments as ['a/b.dart'].

Regardless of which answer was correct, having different answers for the paths/basename was lead to odd errors like being able to create a file but not delete it.