### PR TITLE
Cache path context in LocalFileSystem

### DIFF
--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 5.1.1
+
+* Cache the path context for `LocalFileSystem`.
+
 #### 5.1.0
 
 * Added a new `MemoryFileSystem` constructor to use a test clock

--- a/packages/file/lib/src/backends/local/local_file_system.dart
+++ b/packages/file/lib/src/backends/local/local_file_system.dart
@@ -50,7 +50,10 @@ class LocalFileSystem extends FileSystem {
   Directory get currentDirectory => directory(io.Directory.current.path);
 
   @override
-  set currentDirectory(dynamic path) => io.Directory.current = path;
+  set currentDirectory(dynamic path) {
+    _expandoContext[this] = null;
+    io.Directory.current = path;
+  }
 
   @override
   Future<io.FileStat> stat(String path) => io.FileStat.stat(path);

--- a/packages/file/lib/src/backends/local/local_file_system.dart
+++ b/packages/file/lib/src/backends/local/local_file_system.dart
@@ -12,6 +12,10 @@ import 'local_directory.dart';
 import 'local_file.dart';
 import 'local_link.dart';
 
+// Use an expando To avoid expensive re-creations of the Context object without
+// removing the const constructor.
+final Expando<p.Context> _expandoContext = Expando<p.Context>();
+
 /// A wrapper implementation around `dart:io`'s implementation.
 ///
 /// Since this implementation of the [FileSystem] interface delegates to
@@ -31,8 +35,9 @@ class LocalFileSystem extends FileSystem {
   Link link(dynamic path) => LocalLink(this, io.Link(getPath(path)));
 
   @override
-  p.Context get path => _context ??= p.Context();
-  p.Context _context;
+  p.Context get path {
+    return _expandoContext[this] ??= p.Context();
+  }
 
   /// Gets the directory provided by the operating system for creating temporary
   /// files and directories in. The location of the system temp directory is

--- a/packages/file/lib/src/backends/local/local_file_system.dart
+++ b/packages/file/lib/src/backends/local/local_file_system.dart
@@ -31,7 +31,8 @@ class LocalFileSystem extends FileSystem {
   Link link(dynamic path) => LocalLink(this, io.Link(getPath(path)));
 
   @override
-  p.Context get path => p.Context();
+  p.Context get path => _context ??= p.Context();
+  p.Context _context;
 
   /// Gets the directory provided by the operating system for creating temporary
   /// files and directories in. The location of the system temp directory is

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 5.1.0
+version: 5.1.1
 authors:
 - Matan Lurey <matanl@google.com>
 - Yegor Jbanov <yjbanov@google.com>

--- a/packages/file/test/local_test.dart
+++ b/packages/file/test/local_test.dart
@@ -18,11 +18,11 @@ void main() {
     String cwd;
 
     setUp(() {
-      fs = LocalFileSystem(); // ignore: prefer_const_constructors
+      fs = const LocalFileSystem();
       tmp = io.Directory.systemTemp.createTempSync('file_test_');
       tmp = io.Directory(tmp.resolveSymbolicLinksSync());
       cwd = io.Directory.current.path;
-      io.Directory.current = tmp;
+      fs.currentDirectory = tmp;
     });
 
     tearDown(() {

--- a/packages/file/test/local_test.dart
+++ b/packages/file/test/local_test.dart
@@ -18,7 +18,7 @@ void main() {
     String cwd;
 
     setUp(() {
-      fs = const LocalFileSystem();
+      fs = LocalFileSystem(); // ignore: prefer_const_constructors
       tmp = io.Directory.systemTemp.createTempSync('file_test_');
       tmp = io.Directory(tmp.resolveSymbolicLinksSync());
       cwd = io.Directory.current.path;

--- a/packages/file/test/local_test.dart
+++ b/packages/file/test/local_test.dart
@@ -153,5 +153,9 @@ void main() {
         expect(fs.link('/foo').toString(), "LocalLink: '/foo'");
       });
     });
+
+    test('caches context value', () {
+      expect(identical(fs.path, fs.path), true);
+    });
   });
 }


### PR DESCRIPTION
The context object is currently recreated every time the getter is accessed on the LocalFileSystem class. This ends up going through a fairly expensive codepath each time, hitting the filesystem to determine the current working directory. Here it is in a flame chart for the flutter tool:

![2019-12-28](https://user-images.githubusercontent.com/8975114/71541585-182c6680-2910-11ea-9f7d-364aee32a48e.png)

see https://github.com/dart-lang/path/blob/3d671f4cb5b8234cf2b47f44f03c20698b3bdd88/lib/path.dart#L83

Since the LocalFileSystem has a const constructor, I cached the const using an expando. This guarantees that unique local files systems (created with new) will have their own contexts, while still avoiding the re-creation otherwise.
