### PR TITLE
Add a dartdoc comment for RealNode.clock

### DIFF
--- a/packages/file/lib/src/backends/memory/node.dart
+++ b/packages/file/lib/src/backends/memory/node.dart
@@ -153,6 +153,7 @@ abstract class RealNode extends Node {
     accessed = now;
   }
 
+  /// See [NodeBasedFileSystem.clock].
   Clock get clock => parent.clock;
 
   /// Last changed time in milliseconds since the Epoch.


### PR DESCRIPTION
Add a dartdoc comment for `RealNode.clock` to quiet an analysis
complaint.