### PR TITLE
Enable more "File > open" tests

### DIFF
--- a/packages/file/lib/src/backends/record_replay/codecs.dart
+++ b/packages/file/lib/src/backends/record_replay/codecs.dart
@@ -465,6 +465,15 @@ class Uint8ListToPlainList extends Converter<Uint8List, List<int>> {
   List<int> convert(Uint8List input) => List<int>.from(input);
 }
 
+/// Converts a simple [List<int>] to a [Uint8List].
+class ToUint8List extends Converter<List<int>, Uint8List> {
+  /// Creates a new [ToUint8List].
+  const ToUint8List();
+
+  @override
+  Uint8List convert(List<int> input) => Uint8List.fromList(input);
+}
+
 /// Revives a [Directory] entity reference into a [ReplayDirectory].
 class ReviveDirectory extends Converter<String, Directory> {
   /// Creates a new [ReviveDirectory].

--- a/packages/file/lib/src/backends/record_replay/replay_random_access_file.dart
+++ b/packages/file/lib/src/backends/record_replay/replay_random_access_file.dart
@@ -25,13 +25,15 @@ class ReplayRandomAccessFile extends Object
 
     Converter<List<dynamic>, Uint8List> reviveUint8List =
         const CastList<dynamic, int>().fuse(const ToUint8List());
+    Converter<List<dynamic>, Future<Uint8List>> reviveUint8ListFuture =
+        reviveUint8List.fuse(const ToFuture<Uint8List>());
 
     methods.addAll(<Symbol, Converter<dynamic, dynamic>>{
       #close: reviveRandomAccessFileAsFuture,
       #closeSync: const Passthrough<Null>(),
       #readByte: const ToFuture<int>(),
       #readByteSync: const Passthrough<int>(),
-      #read: reviveUint8List.fuse(const ToFuture<Uint8List>()),
+      #read: reviveUint8ListFuture,
       #readSync: reviveUint8List,
       #readInto: const ToFuture<int>(),
       #readIntoSync: const Passthrough<int>(),

--- a/packages/file/lib/src/backends/record_replay/replay_random_access_file.dart
+++ b/packages/file/lib/src/backends/record_replay/replay_random_access_file.dart
@@ -23,13 +23,16 @@ class ReplayRandomAccessFile extends Object
     Converter<String, Future<RandomAccessFile>> reviveRandomAccessFileAsFuture =
         ReviveRandomAccessFile(_fileSystem).fuse(toFuture);
 
+    Converter<List<dynamic>, Uint8List> reviveUint8List =
+        const CastList<dynamic, int>().fuse(const ToUint8List());
+
     methods.addAll(<Symbol, Converter<dynamic, dynamic>>{
       #close: reviveRandomAccessFileAsFuture,
       #closeSync: const Passthrough<Null>(),
       #readByte: const ToFuture<int>(),
       #readByteSync: const Passthrough<int>(),
-      #read: const ToFuture<Uint8List>(),
-      #readSync: const Passthrough<Uint8List>(),
+      #read: reviveUint8List.fuse(const ToFuture<Uint8List>()),
+      #readSync: reviveUint8List,
       #readInto: const ToFuture<int>(),
       #readIntoSync: const Passthrough<int>(),
       #writeByte: reviveRandomAccessFileAsFuture,

--- a/packages/file/test/chroot_test.dart
+++ b/packages/file/test/chroot_test.dart
@@ -23,12 +23,7 @@ void main() {
     }
 
     group('memoryBacked', () {
-      runCommonTests(
-        createMemoryBackedChrootFileSystem,
-        skip: <String>[
-          'File > open', // Not yet implemented in MemoryFileSystem
-        ],
-      );
+      runCommonTests(createMemoryBackedChrootFileSystem);
     });
 
     group('localBacked', () {

--- a/packages/file/test/recording_test.dart
+++ b/packages/file/test/recording_test.dart
@@ -333,12 +333,7 @@ void main() {
       recording = fs.recording;
     });
 
-    runCommonTests(
-      () => fs,
-      skip: <String>[
-        'File > open', // Not yet implemented in MemoryFileSystem
-      ],
-    );
+    runCommonTests(() => fs);
 
     group('recording', () {
       test('supportsMultipleActions', () {

--- a/packages/file/test/replay_test.dart
+++ b/packages/file/test/replay_test.dart
@@ -46,7 +46,7 @@ void main() {
         'File > openWrite > ioSink > throwsIfAddError',
         'File > openWrite > ioSink > addStream > blocks.*',
 
-        'File > open', // Not yet implemented in MemoryFileSystem
+        'File > open', // TODO(jamesderlin): Enable this, https://github.com/google/file.dart/issues/144
       ],
     );
 

--- a/packages/file/test/replay_test.dart
+++ b/packages/file/test/replay_test.dart
@@ -46,7 +46,11 @@ void main() {
         'File > openWrite > ioSink > throwsIfAddError',
         'File > openWrite > ioSink > addStream > blocks.*',
 
-        'File > open', // TODO(jamesderlin): Enable this, https://github.com/google/file.dart/issues/144
+        // TODO(jamesderlin): ReplayFileSystem does not yet support functions
+        // that mutate arguments, and error-checking for async functions is not
+        // implemented (https://github.com/google/file.dart/issues/144)
+        'File > open .* RandomAccessFile .* readInto.*',
+        'File > open .* RandomAccessFile .* throwsIfAsyncUnawaited',
       ],
     );
 


### PR DESCRIPTION
When I added a `MemoryFileSystem`-based implementation of
`RandomAccessFile` in https://github.com/google/file.dart/pull/136,
I enabled `File > open` tests for `test/memory_test.dart` but did not
notice that various other tests depend on `MemoryFileSystem` and also
explicitly disabled them.

Enable them for `chroot_test.dart` and for `recording_test.dart`.

Partially enable them for `replay_test.dart`.  This uncovered a type
error in `ReplayFile.read`/`readSync`.  Fix them them to explicitly
convert the input (read from a JSON integer array) into a `Uint8List`.

Fixes part of https://github.com/google/file.dart/issues/144.
