### PR TITLE
Fix type error when attempting to enable "File > open" replay tests

### DIFF
--- a/packages/file/lib/src/backends/record_replay/codecs.dart
+++ b/packages/file/lib/src/backends/record_replay/codecs.dart
@@ -465,6 +465,15 @@ class Uint8ListToPlainList extends Converter<Uint8List, List<int>> {
   List<int> convert(Uint8List input) => List<int>.from(input);
 }
 
+/// Converts a simple [List<int>] to a [Uint8List].
+class ToUint8List extends Converter<List<int>, Uint8List> {
+  /// Creates a new [ToUint8List].
+  const ToUint8List();
+
+  @override
+  Uint8List convert(List<int> input) => Uint8List.fromList(input);
+}
+
 /// Revives a [Directory] entity reference into a [ReplayDirectory].
 class ReviveDirectory extends Converter<String, Directory> {
   /// Creates a new [ReviveDirectory].

--- a/packages/file/lib/src/backends/record_replay/replay_random_access_file.dart
+++ b/packages/file/lib/src/backends/record_replay/replay_random_access_file.dart
@@ -25,13 +25,15 @@ class ReplayRandomAccessFile extends Object
 
     Converter<List<dynamic>, Uint8List> reviveUint8List =
         const CastList<dynamic, int>().fuse(const ToUint8List());
+    Converter<List<dynamic>, Future<Uint8List>> reviveUint8ListFuture =
+        reviveUint8List.fuse(const ToFuture<Uint8List>());
 
     methods.addAll(<Symbol, Converter<dynamic, dynamic>>{
       #close: reviveRandomAccessFileAsFuture,
       #closeSync: const Passthrough<Null>(),
       #readByte: const ToFuture<int>(),
       #readByteSync: const Passthrough<int>(),
-      #read: reviveUint8List.fuse(const ToFuture<Uint8List>()),
+      #read: reviveUint8ListFuture,
       #readSync: reviveUint8List,
       #readInto: const ToFuture<int>(),
       #readIntoSync: const Passthrough<int>(),

--- a/packages/file/lib/src/backends/record_replay/replay_random_access_file.dart
+++ b/packages/file/lib/src/backends/record_replay/replay_random_access_file.dart
@@ -23,13 +23,16 @@ class ReplayRandomAccessFile extends Object
     Converter<String, Future<RandomAccessFile>> reviveRandomAccessFileAsFuture =
         ReviveRandomAccessFile(_fileSystem).fuse(toFuture);
 
+    Converter<List<dynamic>, Uint8List> reviveUint8List =
+        const CastList<dynamic, int>().fuse(const ToUint8List());
+
     methods.addAll(<Symbol, Converter<dynamic, dynamic>>{
       #close: reviveRandomAccessFileAsFuture,
       #closeSync: const Passthrough<Null>(),
       #readByte: const ToFuture<int>(),
       #readByteSync: const Passthrough<int>(),
-      #read: const ToFuture<Uint8List>(),
-      #readSync: const Passthrough<Uint8List>(),
+      #read: reviveUint8List.fuse(const ToFuture<Uint8List>()),
+      #readSync: reviveUint8List,
       #readInto: const ToFuture<int>(),
       #readIntoSync: const Passthrough<int>(),
       #writeByte: reviveRandomAccessFileAsFuture,


### PR DESCRIPTION
Fix type error when attempting to enable "File > open" replay tests

Fix `ReplayFile.read`/`readSync` to explicitly convert the input
(read from a JSON integer array) into a `Uint8List`.

Fixes one of the failures in https://github.com/google/file.dart/issues/144.
