### PR TITLE
Fix and refactor NoMatchingInvocationError.toString()

### DIFF
--- a/packages/file/lib/src/backends/record_replay/common.dart
+++ b/packages/file/lib/src/backends/record_replay/common.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'codecs.dart';
 import 'events.dart';
 
 /// Encoded value of the file system in a recording.
@@ -154,4 +155,30 @@ bool _areMapsEqual<K, V>(Map<K, V> map1, Map<K, V> map2) {
         return map1.containsKey(key) == map2.containsKey(key) &&
             deeplyEqual(map1[key], map2[key]);
       });
+}
+
+/// Returns a human-readable representation of an [Invocation].
+String describeInvocation(Invocation invocation) {
+  StringBuffer buf = StringBuffer();
+  buf.write(getSymbolName(invocation.memberName));
+  if (invocation.isMethod) {
+    buf.write('(');
+    int i = 0;
+    for (dynamic arg in invocation.positionalArguments) {
+      if (i++ > 0) {
+        buf.write(', ');
+      }
+      buf.write(Error.safeToString(encode(arg)));
+    }
+    invocation.namedArguments.forEach((Symbol name, dynamic value) {
+      if (i++ > 0) {
+        buf.write(', ');
+      }
+      buf.write('${getSymbolName(name)}: ${encode(value)}');
+    });
+    buf.write(')');
+  } else if (invocation.isSetter) {
+    buf.write(Error.safeToString(encode(invocation.positionalArguments[0])));
+  }
+  return buf.toString();
 }

--- a/packages/file/lib/src/backends/record_replay/common.dart
+++ b/packages/file/lib/src/backends/record_replay/common.dart
@@ -174,7 +174,7 @@ String describeInvocation(Invocation invocation) {
       if (i++ > 0) {
         buf.write(', ');
       }
-      buf.write('${getSymbolName(name)}: ${encode(value)}');
+      buf.write('${getSymbolName(name)}: ${Error.safeToString(encode(value))}');
     });
     buf.write(')');
   } else if (invocation.isSetter) {

--- a/packages/file/lib/src/backends/record_replay/errors.dart
+++ b/packages/file/lib/src/backends/record_replay/errors.dart
@@ -24,10 +24,10 @@ class NoMatchingInvocationError extends Error {
       buf.write('(');
       int i = 0;
       for (dynamic arg in invocation.positionalArguments) {
-        buf.write(Error.safeToString(encode(arg)));
         if (i++ > 0) {
           buf.write(', ');
         }
+        buf.write(Error.safeToString(encode(arg)));
       }
       invocation.namedArguments.forEach((Symbol name, dynamic value) {
         if (i++ > 0) {

--- a/packages/file/lib/src/backends/record_replay/errors.dart
+++ b/packages/file/lib/src/backends/record_replay/errors.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'codecs.dart';
 import 'common.dart';
 
 /// Error thrown during replay when there is no matching invocation in the
@@ -16,31 +15,8 @@ class NoMatchingInvocationError extends Error {
   final Invocation invocation;
 
   @override
-  String toString() {
-    StringBuffer buf = StringBuffer();
-    buf.write('No matching invocation found: ');
-    buf.write(getSymbolName(invocation.memberName));
-    if (invocation.isMethod) {
-      buf.write('(');
-      int i = 0;
-      for (dynamic arg in invocation.positionalArguments) {
-        if (i++ > 0) {
-          buf.write(', ');
-        }
-        buf.write(Error.safeToString(encode(arg)));
-      }
-      invocation.namedArguments.forEach((Symbol name, dynamic value) {
-        if (i++ > 0) {
-          buf.write(', ');
-        }
-        buf.write('${getSymbolName(name)}: ${encode(value)}');
-      });
-      buf.write(')');
-    } else if (invocation.isSetter) {
-      buf.write(Error.safeToString(encode(invocation.positionalArguments[0])));
-    }
-    return buf.toString();
-  }
+  String toString() =>
+      'No matching invocation found: ${describeInvocation(invocation)}';
 }
 
 /// Exception thrown during replay when an invocation recorded error, but we

--- a/packages/file/test/replay_test.dart
+++ b/packages/file/test/replay_test.dart
@@ -7,6 +7,8 @@ import 'dart:async';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:file/record_replay.dart';
+import 'package:file/src/backends/record_replay/common.dart'
+    show describeInvocation;
 import 'package:file_testing/file_testing.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
@@ -200,6 +202,41 @@ void main() {
         expect(() => fs.typeSync('/'), throwsNoMatchingInvocationError);
         expect(replayType, type);
       });
+    });
+  });
+
+  group('describeInvocation', () {
+    test('noArguments', () {
+      expect(
+        describeInvocation(Invocation.method(#foo, [])),
+        'foo()',
+      );
+    });
+
+    test('onlyPositionalArguments', () {
+      expect(
+        describeInvocation(Invocation.method(#foo, [1, 'bar', null])),
+        'foo(1, "bar", null)',
+      );
+    });
+
+    test('onlyNamedArguments', () {
+      expect(
+        describeInvocation(
+            Invocation.method(#foo, [], {#x: 2, #y: 'baz', #z: null})),
+        'foo(x: 2, y: "baz", z: null)',
+      );
+    });
+
+    test('positionalAndNamedArguments', () {
+      expect(
+        describeInvocation(Invocation.method(
+          #foo,
+          [1, 'bar', null],
+          {#x: 2, #y: 'baz', #z: null},
+        )),
+        'foo(1, "bar", null, x: 2, y: "baz", z: null)',
+      );
     });
   });
 }


### PR DESCRIPTION
1. `NoMatchingInvocation.toString()` attempted to avoid printing a
   comma after the last argument, but the code was backwards, instead
   adding a trailing comma and omitting the comma after the first
   argument.  Move the code to print the comma to the beginning of
   the loop iteration; this also matches handling of named arguments.

2. Break up `NoMatchingInvocationError.toString()` so that we can
   generate human-readable string representations of `Invocation`s
   elsewhere for debugging.