### PR TITLE
Remove some stale TODOs

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -141,7 +141,7 @@ linter:
     - throw_in_finally
     # - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
-    # - unawaited_futures # too many false positives
+    - unawaited_futures
     # - unnecessary_await_in_return # not yet tested
     - unnecessary_brace_in_string_interps
     - unnecessary_const

--- a/packages/file/lib/src/backends/memory/memory_file.dart
+++ b/packages/file/lib/src/backends/memory/memory_file.dart
@@ -330,9 +330,11 @@ class _FileSink implements io.IOSink {
   @override
   void add(List<int> data) {
     _checkNotStreaming();
-    if (!_isClosed) {
-      _addData(data);
+    if (_isClosed) {
+      throw StateError('StreamSink is closed');
     }
+
+    _addData(data);
   }
 
   @override
@@ -387,8 +389,7 @@ class _FileSink implements io.IOSink {
   }
 
   @override
-  // TODO(tvolkert): Change to Future<Null> once Dart 1.22 is stable
-  Future<dynamic> flush() {
+  Future<void> flush() {
     _checkNotStreaming();
     return _pendingWrites;
   }

--- a/packages/file/lib/src/backends/memory/memory_random_access_file.dart
+++ b/packages/file/lib/src/backends/memory/memory_random_access_file.dart
@@ -188,6 +188,7 @@ class MemoryRandomAccessFile implements io.RandomAccessFile {
   ]) {
     _checkOpen();
     _checkAsync();
+    // TODO(jamesderlin): Implement, https://github.com/google/file.dart/issues/140
     throw UnimplementedError('TODO');
   }
 
@@ -310,6 +311,7 @@ class MemoryRandomAccessFile implements io.RandomAccessFile {
   void unlockSync([int start = 0, int end = -1]) {
     _checkOpen();
     _checkAsync();
+    // TODO(jamesderlin): Implement, https://github.com/google/file.dart/issues/140
     throw UnimplementedError('TODO');
   }
 

--- a/packages/file/lib/src/backends/record_replay/proxy.dart
+++ b/packages/file/lib/src/backends/record_replay/proxy.dart
@@ -33,7 +33,7 @@ class MethodProxy {
       // The method is being invoked. Capture the arguments, and invoke the
       // method on the proxy object. We have to synthesize an invocation, since
       // our current `invocation` object represents the invocation of `call()`.
-      return _proxyObject.noSuchMethod(_MethodInvocationProxy(
+      return _proxyObject.noSuchMethod(Invocation.method(
         _methodName,
         invocation.positionalArguments,
         invocation.namedArguments,
@@ -41,31 +41,4 @@ class MethodProxy {
     }
     return super.noSuchMethod(invocation);
   }
-}
-
-// TODO(tvolkert): remove (https://github.com/dart-lang/sdk/issues/28706)
-class _MethodInvocationProxy extends Invocation {
-  _MethodInvocationProxy(
-    this.memberName,
-    this.positionalArguments,
-    this.namedArguments,
-  );
-
-  @override
-  final Symbol memberName;
-
-  @override
-  final List<dynamic> positionalArguments;
-
-  @override
-  final Map<Symbol, dynamic> namedArguments;
-
-  @override
-  final bool isMethod = true;
-
-  @override
-  final bool isGetter = false;
-
-  @override
-  final bool isSetter = false;
 }

--- a/packages/file/test/chroot_test.dart
+++ b/packages/file/test/chroot_test.dart
@@ -48,33 +48,6 @@ void main() {
       runCommonTests(
         () => fs,
         skip: <String>[
-          // API doesn't exit in dart:io until Dart 1.23
-          'File > lastAccessed',
-          'File > setLastAccessed',
-          'File > setLastModified',
-
-          // https://github.com/dart-lang/sdk/issues/28170
-          'File > create > throwsIfAlreadyExistsAsDirectory',
-          'File > create > throwsIfAlreadyExistsAsLinkToDirectory',
-
-          // https://github.com/dart-lang/sdk/issues/28172
-          'File > length > throwsIfExistsAsDirectory',
-
-          // https://github.com/dart-lang/sdk/issues/28173
-          'File > lastModified > throwsIfExistsAsDirectory',
-
-          // https://github.com/dart-lang/sdk/issues/28174
-          '.+ > RandomAccessFile > writeFromWithStart',
-          '.+ > RandomAccessFile > writeFromWithStartAndEnd',
-
-          // https://github.com/dart-lang/sdk/issues/28201
-          'Link > update > throwsIfLinkDoesntExistAtTail',
-          'Link > update > throwsIfLinkDoesntExistViaTraversal',
-
-          // https://github.com/dart-lang/sdk/issues/28202
-          'Link > rename > throwsIfSourceDoesntExistAtTail',
-          'Link > rename > throwsIfSourceDoesntExistViaTraversal',
-
           // https://github.com/dart-lang/sdk/issues/28275
           'Link > rename > throwsIfDestinationExistsAsDirectory',
 

--- a/packages/file/test/common_tests.dart
+++ b/packages/file/test/common_tests.dart
@@ -2285,15 +2285,12 @@ void runCommonTests(
             expect(await f.readAsString(), 'Hello world\n');
           });
 
-          // TODO(tvolkert): Fix and re-enable: http://dartbug.com/29554
-          /*
           test('ignoresDataWrittenAfterClose', () async {
             sink.write('Before close');
             await closeSink();
-            sink.write('After close');
+            expect(() => sink.write('After close'), throwsStateError);
             expect(await f.readAsString(), 'Before close');
           });
-          */
 
           test('ignoresCloseAfterAlreadyClosed', () async {
             sink.write('Hello world');

--- a/packages/file/test/local_test.dart
+++ b/packages/file/test/local_test.dart
@@ -98,37 +98,8 @@ void main() {
       () => fs,
       root: () => tmp.path,
       skip: <String>[
-        // API doesn't exit in dart:io until Dart 1.23
-        'File > lastAccessed',
-        'File > setLastAccessed',
-        'File > setLastModified',
-
-        // https://github.com/dart-lang/sdk/issues/28170
-        'File > create > throwsIfAlreadyExistsAsDirectory',
-        'File > create > throwsIfAlreadyExistsAsLinkToDirectory',
-
         // https://github.com/dart-lang/sdk/issues/28171
         'File > rename > throwsIfDestinationExistsAsLinkToDirectory',
-
-        // https://github.com/dart-lang/sdk/issues/28172
-        'File > length > throwsIfExistsAsDirectory',
-
-        // https://github.com/dart-lang/sdk/issues/28173
-        'File > lastModified > throwsIfExistsAsDirectory',
-
-        // https://github.com/dart-lang/sdk/issues/28174
-        '.+ > RandomAccessFile > writeFromWithStart',
-        '.+ > RandomAccessFile > writeFromWithStartAndEnd',
-
-        // https://github.com/dart-lang/sdk/issues/28201
-        'Link > delete > throwsIfLinkDoesntExistAtTail',
-        'Link > delete > throwsIfLinkDoesntExistViaTraversal',
-        'Link > update > throwsIfLinkDoesntExistAtTail',
-        'Link > update > throwsIfLinkDoesntExistViaTraversal',
-
-        // https://github.com/dart-lang/sdk/issues/28202
-        'Link > rename > throwsIfSourceDoesntExistAtTail',
-        'Link > rename > throwsIfSourceDoesntExistViaTraversal',
 
         // https://github.com/dart-lang/sdk/issues/28275
         'Link > rename > throwsIfDestinationExistsAsDirectory',

--- a/packages/file/test/replay_test.dart
+++ b/packages/file/test/replay_test.dart
@@ -45,6 +45,7 @@ void main() {
         'File > openWrite > throws.*',
         'File > openWrite > ioSink > throwsIfAddError',
         'File > openWrite > ioSink > addStream > blocks.*',
+        'File > openWrite > ioSink > ignoresDataWrittenAfterClose',
 
         'File > open', // Not yet implemented in MemoryFileSystem
       ],


### PR DESCRIPTION
Remove some TODOs that depended on Dart SDK issues that have since
been fixed.

* Re-enable a test that attempts writing after the `IOSink` is
  closed.

* Enable various other skipped tests.

* Remove `_MethodInvocationProxy`.

Also add some GitHub issue references for some TODOs that I added
earlier.