### PR TITLE
Per instance temp directory naming

### DIFF
--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 5.2.1
+
+* systemTemp directories created by `MemoryFileSystem` will allot names
+  based on the file system instance instead of globally.
+
 #### 5.2.0
 
 * Added a `MemoryRandomAccessFile` class and implemented

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 5.2.0
+version: 5.2.1
 authors:
 - Matan Lurey <matanl@google.com>
 - Yegor Jbanov <yjbanov@google.com>

--- a/packages/file/test/memory_test.dart
+++ b/packages/file/test/memory_test.dart
@@ -110,4 +110,25 @@ void main() {
       raf.closeSync();
     }
   });
+
+  test('MemoryFileSystem.systemTempDirectory test', () {
+    final MemoryFileSystem fs = MemoryFileSystem.test();
+
+    final io.Directory fooA = fs.systemTempDirectory.createTempSync('foo');
+    final io.Directory fooB = fs.systemTempDirectory.createTempSync('foo');
+
+    expect(fooA.path, '/.tmp_rand0/foorand0');
+    expect(fooB.path, '/.tmp_rand0/foorand1');
+
+    final MemoryFileSystem secondFs = MemoryFileSystem.test();
+
+    final io.Directory fooAA =
+        secondFs.systemTempDirectory.createTempSync('foo');
+    final io.Directory fooBB =
+        secondFs.systemTempDirectory.createTempSync('foo');
+
+    // Names are recycled with a new instance
+    expect(fooAA.path, '/.tmp_rand0/foorand0');
+    expect(fooBB.path, '/.tmp_rand0/foorand1');
+  });
 }


### PR DESCRIPTION
Currently the memory file system uses a static to track unique names for the system temp directory. This causes tests that make assertions about created directories to only work in a particular order, even if the file system instance is not shared.

Updates the static to an Expando, which performs the same logic but per-instance.