### PR TITLE
Fix CHANGELOG.md and update package version

### DIFF
--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 5.2.2-dev
+* Fixed incorrect formatting in `NoMatchingInvocationError.toString()`.
+* Fixed more test flakiness.
+* Enabled more tests.
+* Internal cleanup.
+
 #### 5.2.1
 
 * systemTemp directories created by `MemoryFileSystem` will allot names
@@ -7,8 +13,7 @@
 * `RecordingFile.readAsLine()`/`readAsLinesSync()` now always record a final
   newline.
 * `MemoryFile.flush()` now returns `Future<void>` instead of `Future<dynamic>`.
-* Fixed incorrect formatting in `NoMatchingInvocationError.toString()`.
-* Fixed a lot of test flakiness.
+* Fixed some test flakiness.
 * Enabled more tests.
 * Internal cleanup.
 

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 5.2.1
+version: 5.2.2-dev
 authors:
 - Matan Lurey <matanl@google.com>
 - Yegor Jbanov <yjbanov@google.com>


### PR DESCRIPTION
Some of my earlier commits didn't make the cutoff for 5.2.1.  Adjust
CHANGELOG.md accordingly.