### PR TITLE
[null-safety] remove implicit-dynamic, intl in preparation for null-safety

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,6 @@
 analyzer:
   strong-mode:
+    implicit-casts: false
     implicit-dynamic: false
   errors:
     # treat missing required parameters as a warning (not a hint)
@@ -8,10 +9,6 @@ analyzer:
     missing_return: warning
     # allow having TODOs in the code
     todo: ignore
-    # Ignore analyzer hints for updating pubspecs when using Future or
-    # Stream and not importing dart:async
-    # Please see https://github.com/flutter/flutter/pull/24528 for details.
-    sdk_version_async_exported_from_core: ignore
 
 linter:
   rules:

--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Fixed more test flakiness.
 * Enabled more tests.
 * Internal cleanup.
+* Remove implicit dynamic in preparation for null safety.
+* Remove dependency on Intl
 
 #### 5.2.1
 

--- a/packages/file/lib/src/backends/chroot/chroot_directory.dart
+++ b/packages/file/lib/src/backends/chroot/chroot_directory.dart
@@ -137,7 +137,7 @@ class _ChrootDirectory extends _ChrootFileSystemEntity<Directory, io.Directory>
     bool recursive = false,
     bool followLinks = true,
   }) {
-    Directory delegate = this.delegate;
+    Directory delegate = this.delegate as Directory;
     String dirname = delegate.path;
     return delegate
         .list(recursive: recursive, followLinks: followLinks)
@@ -149,7 +149,7 @@ class _ChrootDirectory extends _ChrootFileSystemEntity<Directory, io.Directory>
     bool recursive = false,
     bool followLinks = true,
   }) {
-    Directory delegate = this.delegate;
+    Directory delegate = this.delegate as Directory;
     String dirname = delegate.path;
     return delegate
         .listSync(recursive: recursive, followLinks: followLinks)

--- a/packages/file/lib/src/backends/chroot/chroot_file.dart
+++ b/packages/file/lib/src/backends/chroot/chroot_file.dart
@@ -252,7 +252,7 @@ class _ChrootFile extends _ChrootFileSystemEntity<File, io.File>
 
   @override
   Stream<Uint8List> openRead([int start, int end]) =>
-      getDelegate(followLinks: true).openRead(start, end);
+      getDelegate(followLinks: true).openRead(start, end).cast<Uint8List>();
 
   @override
   IOSink openWrite({

--- a/packages/file/lib/src/backends/chroot/chroot_file_system.dart
+++ b/packages/file/lib/src/backends/chroot/chroot_file_system.dart
@@ -112,9 +112,9 @@ class ChrootFileSystem extends FileSystem {
       case FileSystemEntityType.directory:
         break;
       case FileSystemEntityType.notFound:
-        throw common.noSuchFileOrDirectory(path);
+        throw common.noSuchFileOrDirectory(path as String);
       default:
-        throw common.notADirectory(path);
+        throw common.notADirectory(path as String);
     }
     assert(() {
       p.Context ctx = delegate.path;

--- a/packages/file/lib/src/backends/chroot/chroot_file_system_entity.dart
+++ b/packages/file/lib/src/backends/chroot/chroot_file_system_entity.dart
@@ -52,7 +52,8 @@ abstract class _ChrootFileSystemEntity<T extends FileSystemEntity,
 
   @override
   Directory wrapDirectory(io.Directory delegate) =>
-      _ChrootDirectory.wrapped(fileSystem, delegate, relative: !isAbsolute);
+      _ChrootDirectory.wrapped(fileSystem, delegate as Directory,
+          relative: !isAbsolute);
 
   @override
   File wrapFile(io.File delegate) =>

--- a/packages/file/lib/src/backends/memory/common.dart
+++ b/packages/file/lib/src/backends/memory/common.dart
@@ -10,6 +10,6 @@ typedef PathGenerator = dynamic Function();
 /// Throws a `FileSystemException` if [object] is null.
 void checkExists(Object object, PathGenerator path) {
   if (object == null) {
-    throw common.noSuchFileOrDirectory(path());
+    throw common.noSuchFileOrDirectory(path() as String);
   }
 }

--- a/packages/file/lib/src/backends/memory/memory_directory.dart
+++ b/packages/file/lib/src/backends/memory/memory_directory.dart
@@ -74,7 +74,7 @@ class MemoryDirectory extends MemoryFileSystemEntity
     String fullPath = fileSystem.path.join(path, prefix);
     String dirname = fileSystem.path.dirname(fullPath);
     String basename = fileSystem.path.basename(fullPath);
-    DirectoryNode node = fileSystem.findNode(dirname);
+    DirectoryNode node = fileSystem.findNode(dirname) as DirectoryNode;
     checkExists(node, () => dirname);
     utils.checkIsDir(node, () => dirname);
     int _tempCounter = _systemTempCounter[fileSystem] ?? 0;
@@ -99,14 +99,14 @@ class MemoryDirectory extends MemoryFileSystemEntity
             throw common.directoryNotEmpty(newPath);
           }
         },
-      );
+      ) as Directory;
 
   @override
   Directory get parent =>
       (backingOrNull?.isRoot ?? false) ? this : super.parent;
 
   @override
-  Directory get absolute => super.absolute;
+  Directory get absolute => super.absolute as Directory;
 
   @override
   Stream<FileSystemEntity> list({
@@ -123,7 +123,7 @@ class MemoryDirectory extends MemoryFileSystemEntity
     bool recursive = false,
     bool followLinks = true,
   }) {
-    DirectoryNode node = backing;
+    DirectoryNode node = backing as DirectoryNode;
     List<FileSystemEntity> listing = <FileSystemEntity>[];
     List<_PendingListTask> tasks = <_PendingListTask>[
       _PendingListTask(
@@ -139,7 +139,9 @@ class MemoryDirectory extends MemoryFileSystemEntity
       task.dir.children.forEach((String name, Node child) {
         Set<LinkNode> breadcrumbs = Set<LinkNode>.from(task.breadcrumbs);
         String childPath = fileSystem.path.join(task.path, name);
-        while (followLinks && utils.isLink(child) && breadcrumbs.add(child)) {
+        while (followLinks &&
+            utils.isLink(child) &&
+            breadcrumbs.add(child as LinkNode)) {
           Node referent = (child as LinkNode).referentOrNull;
           if (referent != null) {
             child = referent;
@@ -148,7 +150,8 @@ class MemoryDirectory extends MemoryFileSystemEntity
         if (utils.isDirectory(child)) {
           listing.add(MemoryDirectory(fileSystem, childPath));
           if (recursive) {
-            tasks.add(_PendingListTask(child, childPath, breadcrumbs));
+            tasks.add(_PendingListTask(
+                child as DirectoryNode, childPath, breadcrumbs));
           }
         } else if (utils.isLink(child)) {
           listing.add(MemoryLink(fileSystem, childPath));

--- a/packages/file/lib/src/backends/memory/memory_file.dart
+++ b/packages/file/lib/src/backends/memory/memory_file.dart
@@ -29,10 +29,12 @@ class MemoryFile extends MemoryFileSystemEntity implements File {
     if (node == null) {
       node = _doCreate();
     } else {
-      node = utils.isLink(node) ? utils.resolveLinks(node, () => path) : node;
+      node = utils.isLink(node)
+          ? utils.resolveLinks(node as LinkNode, () => path)
+          : node;
       utils.checkType(expectedType, node.type, () => path);
     }
-    return node;
+    return node as FileNode;
   }
 
   @override
@@ -87,14 +89,14 @@ class MemoryFile extends MemoryFileSystemEntity implements File {
                 : common.isADirectory(path);
           }
         },
-      );
+      ) as File;
 
   @override
   Future<File> copy(String newPath) async => copySync(newPath);
 
   @override
   File copySync(String newPath) {
-    FileNode sourceNode = resolvedBacking;
+    FileNode sourceNode = resolvedBacking as FileNode;
     fileSystem.findNode(
       newPath,
       segmentVisitor: (
@@ -108,7 +110,8 @@ class MemoryFile extends MemoryFileSystemEntity implements File {
           if (child != null) {
             if (utils.isLink(child)) {
               List<String> ledger = <String>[];
-              child = utils.resolveLinks(child, () => newPath, ledger: ledger);
+              child = utils.resolveLinks(child as LinkNode, () => newPath,
+                  ledger: ledger);
               checkExists(child, () => newPath);
               parent = child.parent;
               childName = ledger.last;
@@ -134,7 +137,7 @@ class MemoryFile extends MemoryFileSystemEntity implements File {
   int lengthSync() => (resolvedBacking as FileNode).size;
 
   @override
-  File get absolute => super.absolute;
+  File get absolute => super.absolute as File;
 
   @override
   Future<DateTime> lastAccessed() async => lastAccessedSync();
@@ -148,7 +151,7 @@ class MemoryFile extends MemoryFileSystemEntity implements File {
 
   @override
   void setLastAccessedSync(DateTime time) {
-    FileNode node = resolvedBacking;
+    FileNode node = resolvedBacking as FileNode;
     node.accessed = time.millisecondsSinceEpoch;
   }
 
@@ -164,7 +167,7 @@ class MemoryFile extends MemoryFileSystemEntity implements File {
 
   @override
   void setLastModifiedSync(DateTime time) {
-    FileNode node = resolvedBacking;
+    FileNode node = resolvedBacking as FileNode;
     node.modified = time.millisecondsSinceEpoch;
   }
 
@@ -187,7 +190,7 @@ class MemoryFile extends MemoryFileSystemEntity implements File {
   @override
   Stream<Uint8List> openRead([int start, int end]) {
     try {
-      FileNode node = resolvedBacking;
+      FileNode node = resolvedBacking as FileNode;
       Uint8List content = node.content;
       if (start != null) {
         content = end == null

--- a/packages/file/lib/src/backends/memory/memory_file_system.dart
+++ b/packages/file/lib/src/backends/memory/memory_file_system.dart
@@ -192,7 +192,7 @@ class _MemoryFileSystem extends FileSystem
   /// Gets the node backing for the current working directory. Note that this
   /// can return null if the directory has been deleted or moved from under our
   /// feet.
-  DirectoryNode get _current => findNode(cwd);
+  DirectoryNode get _current => findNode(cwd) as DirectoryNode;
 
   @override
   Node findNode(
@@ -248,10 +248,11 @@ class _MemoryFileSystem extends FileSystem
           if (segmentVisitor != null) {
             child = segmentVisitor(directory, basename, child, i, finalSegment);
           }
-          child = utils.resolveLinks(child, subpath, ledger: pathWithSymlinks);
+          child = utils.resolveLinks(child as LinkNode, subpath,
+              ledger: pathWithSymlinks);
         } else {
           child = utils.resolveLinks(
-            child,
+            child as LinkNode,
             subpath,
             ledger: pathWithSymlinks,
             tailVisitor: (DirectoryNode parent, String childName, Node child) {
@@ -266,7 +267,7 @@ class _MemoryFileSystem extends FileSystem
       if (i < finalSegment) {
         checkExists(child, subpath);
         utils.checkIsDir(child, subpath);
-        directory = child;
+        directory = child as DirectoryNode;
       }
     }
     return child;

--- a/packages/file/lib/src/backends/memory/memory_file_system_entity.dart
+++ b/packages/file/lib/src/backends/memory/memory_file_system_entity.dart
@@ -73,7 +73,9 @@ abstract class MemoryFileSystemEntity implements FileSystemEntity {
   @protected
   Node get resolvedBacking {
     Node node = backing;
-    node = utils.isLink(node) ? utils.resolveLinks(node, () => path) : node;
+    node = utils.isLink(node)
+        ? utils.resolveLinks(node as LinkNode, () => path)
+        : node;
     utils.checkType(expectedType, node.type, () => path);
     return node;
   }
@@ -262,7 +264,7 @@ abstract class MemoryFileSystemEntity implements FileSystemEntity {
               utils.checkType(expectedType, child.type, () => newPath);
             }
             if (validateOverwriteExistingEntity != null) {
-              validateOverwriteExistingEntity(child);
+              validateOverwriteExistingEntity(child as T);
             }
             parent.children.remove(childName);
           }

--- a/packages/file/lib/src/backends/memory/memory_link.dart
+++ b/packages/file/lib/src/backends/memory/memory_link.dart
@@ -38,7 +38,7 @@ class MemoryLink extends MemoryFileSystemEntity implements Link {
                 : common.invalidArgument(newPath);
           }
         },
-      );
+      ) as Link;
 
   @override
   Future<Link> create(String target, {bool recursive = false}) async {
@@ -99,7 +99,7 @@ class MemoryLink extends MemoryFileSystemEntity implements Link {
   }
 
   @override
-  Link get absolute => super.absolute;
+  Link get absolute => super.absolute as Link;
 
   @override
   @protected

--- a/packages/file/lib/src/backends/memory/utils.dart
+++ b/packages/file/lib/src/backends/memory/utils.dart
@@ -25,7 +25,7 @@ typedef TypeChecker = void Function(Node node);
 /// Throws a [io.FileSystemException] if [node] is not a directory.
 void checkIsDir(Node node, PathGenerator path) {
   if (!isDirectory(node)) {
-    throw common.notADirectory(path());
+    throw common.notADirectory(path() as String);
   }
 }
 
@@ -39,12 +39,12 @@ void checkType(
   if (expectedType != actualType) {
     switch (expectedType) {
       case FileSystemEntityType.directory:
-        throw common.notADirectory(path());
+        throw common.notADirectory(path() as String);
       case FileSystemEntityType.file:
         assert(actualType == FileSystemEntityType.directory);
-        throw common.isADirectory(path());
+        throw common.isADirectory(path() as String);
       case FileSystemEntityType.link:
-        throw common.invalidArgument(path());
+        throw common.invalidArgument(path() as String);
       default:
         // Should not happen
         throw AssertionError();
@@ -89,9 +89,9 @@ Node resolveLinks(
 
   Node node = link;
   while (isLink(node)) {
-    link = node;
-    if (!breadcrumbs.add(node)) {
-      throw common.tooManyLevelsOfSymbolicLinks(path());
+    link = node as LinkNode;
+    if (!breadcrumbs.add(link)) {
+      throw common.tooManyLevelsOfSymbolicLinks(path() as String);
     }
     if (ledger != null) {
       if (link.fs.path.isAbsolute(link.target)) {

--- a/packages/file/lib/src/backends/record_replay/codecs.dart
+++ b/packages/file/lib/src/backends/record_replay/codecs.dart
@@ -147,7 +147,7 @@ class _MapEncoder
     _GenericEncoder generic = const _GenericEncoder();
     Map<String, dynamic> encoded = <String, dynamic>{};
     for (dynamic key in input.keys) {
-      String encodedKey = generic.convert(key);
+      String encodedKey = generic.convert(key) as String;
       encoded[encodedKey] = generic.convert(input[key]);
     }
     return encoded;
@@ -212,11 +212,11 @@ class UriCodec extends Codec<Uri, String> {
 }
 
 /// A [PathContextCodec] serializes and deserializes [path.Context] instances.
-class PathContextCodec extends Codec<path.Context, Map<String, String>> {
+class PathContextCodec extends Codec<path.Context, Map<String, dynamic>> {
   /// Creates a new [PathContextCodec].
   const PathContextCodec();
 
-  static Map<String, String> _encode(path.Context input) {
+  static Map<String, dynamic> _encode(path.Context input) {
     return <String, String>{
       'style': input.style.name,
       'cwd': input.current,
@@ -230,23 +230,23 @@ class PathContextCodec extends Codec<path.Context, Map<String, String>> {
         'windows': path.Style.windows,
         'url': path.Style.url,
       }[input['style']],
-      current: input['cwd'],
+      current: input['cwd'] as String,
     );
   }
 
   /// Converter that serializes [path.Context] instances.
-  static const Converter<path.Context, Map<String, String>> serialize =
-      _ForwardingConverter<path.Context, Map<String, String>>(_encode);
+  static const Converter<path.Context, Map<String, dynamic>> serialize =
+      _ForwardingConverter<path.Context, Map<String, dynamic>>(_encode);
 
   /// Converter that deserializes [path.Context] instances.
   static const Converter<Map<String, dynamic>, path.Context> deserialize =
       _ForwardingConverter<Map<String, dynamic>, path.Context>(_decode);
 
   @override
-  Converter<path.Context, Map<String, String>> get encoder => serialize;
+  Converter<path.Context, Map<String, dynamic>> get encoder => serialize;
 
   @override
-  Converter<Map<String, String>, path.Context> get decoder => deserialize;
+  Converter<Map<String, dynamic>, path.Context> get decoder => deserialize;
 }
 
 class _ResultEncoder extends Converter<ResultReference<dynamic>, Object> {
@@ -429,13 +429,13 @@ class _FileSystemEvent implements FileSystemEvent {
   final Map<String, Object> _data;
 
   @override
-  int get type => _data['type'];
+  int get type => _data['type'] as int;
 
   @override
-  String get path => _data['path'];
+  String get path => _data['path'] as String;
 
   @override
-  bool get isDirectory => _data['isDirectory'];
+  bool get isDirectory => _data['isDirectory'] as bool;
 }
 
 /// Converts an object into a [Future] that completes with that object.
@@ -617,7 +617,7 @@ class ToError extends Converter<dynamic, dynamic> {
   @override
   dynamic convert(dynamic input) {
     if (input is Map) {
-      String errorType = input[kManifestErrorTypeKey];
+      String errorType = input[kManifestErrorTypeKey] as String;
       if (_decoders.containsKey(errorType)) {
         return _decoders[errorType].convert(input);
       }
@@ -644,9 +644,9 @@ class _FSExceptionCodec
   static FileSystemException _decode(Map<String, Object> input) {
     Object osError = input['osError'];
     return FileSystemException(
-      input['message'],
-      input['path'],
-      osError == null ? null : const ToError().convert(osError),
+      input['message'] as String,
+      input['path'] as String,
+      osError == null ? null : const ToError().convert(osError) as OSError,
     );
   }
 
@@ -678,7 +678,7 @@ class _OSErrorCodec extends Codec<OSError, Map<String, Object>> {
   }
 
   static OSError _decode(Map<String, Object> input) {
-    return OSError(input['message'], input['errorCode']);
+    return OSError(input['message'] as String, input['errorCode'] as int);
   }
 
   static const Converter<OSError, Map<String, Object>> serialize =
@@ -711,7 +711,7 @@ class _ArgumentErrorCodec extends Codec<ArgumentError, Map<String, Object>> {
   static ArgumentError _decode(Map<String, Object> input) {
     dynamic message = input['message'];
     dynamic invalidValue = input['invalidValue'];
-    String name = input['name'];
+    String name = input['name'] as String;
     if (invalidValue != null) {
       return ArgumentError.value(invalidValue, name, message);
     } else if (name != null) {
@@ -748,7 +748,7 @@ class _NoSuchMethodErrorCodec
   }
 
   static NoSuchMethodError _decode(Map<String, Object> input) {
-    return _NoSuchMethodError(input['toString']);
+    return _NoSuchMethodError(input['toString'] as String);
   }
 
   static const Converter<NoSuchMethodError, Map<String, Object>> serialize =

--- a/packages/file/lib/src/backends/record_replay/common.dart
+++ b/packages/file/lib/src/backends/record_replay/common.dart
@@ -135,9 +135,10 @@ bool deeplyEqual(dynamic object1, dynamic object2) {
   if (object1.runtimeType != object2.runtimeType) {
     return false;
   } else if (object1 is List) {
-    return _areListsEqual<dynamic>(object1, object2);
+    return _areListsEqual<dynamic>(object1, object2 as List<dynamic>);
   } else if (object1 is Map) {
-    return _areMapsEqual<dynamic, dynamic>(object1, object2);
+    return _areMapsEqual<dynamic, dynamic>(
+        object1, object2 as Map<dynamic, dynamic>);
   } else {
     return object1 == object2;
   }

--- a/packages/file/lib/src/backends/record_replay/events.dart
+++ b/packages/file/lib/src/backends/record_replay/events.dart
@@ -88,10 +88,10 @@ abstract class LiveInvocationEvent<T> implements InvocationEvent<T> {
   T get result {
     dynamic result = _result;
     while (result is ResultReference) {
-      ResultReference<dynamic> reference = result;
+      ResultReference<dynamic> reference = result as ResultReference<dynamic>;
       result = reference.recordedValue;
     }
-    return result;
+    return result as T;
   }
 
   @override
@@ -115,7 +115,7 @@ abstract class LiveInvocationEvent<T> implements InvocationEvent<T> {
   Future<void> get done async {
     dynamic result = _result;
     while (result is ResultReference) {
-      ResultReference<dynamic> reference = result;
+      ResultReference<dynamic> reference = result as ResultReference<dynamic>;
       await reference.complete;
       result = reference.recordedValue;
     }

--- a/packages/file/lib/src/backends/record_replay/mutable_recording.dart
+++ b/packages/file/lib/src/backends/record_replay/mutable_recording.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:file/file.dart';
-import 'package:intl/intl.dart';
 
 import 'codecs.dart';
 import 'common.dart';
@@ -64,7 +63,7 @@ class MutableRecording implements LiveRecording {
   /// It is up to the caller to create the file - it will not exist in the
   /// file system when it is returned from this method.
   File newFile(String name) {
-    String basename = '${NumberFormat('000').format(newUid())}.$name';
+    String basename = '${newUid()}.$name';
     String dirname = destination.path;
     String path = destination.fileSystem.path.join(dirname, basename);
     return destination.fileSystem.file(path);

--- a/packages/file/lib/src/backends/record_replay/recording_directory.dart
+++ b/packages/file/lib/src/backends/record_replay/recording_directory.dart
@@ -16,7 +16,7 @@ class RecordingDirectory extends RecordingFileSystemEntity<Directory>
     implements Directory {
   /// Creates a new `RecordingDirectory`.
   RecordingDirectory(RecordingFileSystem fileSystem, io.Directory delegate)
-      : super(fileSystem, delegate) {
+      : super(fileSystem as RecordingFileSystemImpl, delegate as Directory) {
     methods.addAll(<Symbol, Function>{
       #create: _create,
       #createSync: delegate.createSync,

--- a/packages/file/lib/src/backends/record_replay/recording_file.dart
+++ b/packages/file/lib/src/backends/record_replay/recording_file.dart
@@ -36,7 +36,7 @@ typedef _BlobDataAsyncWriter<T> = Future<void> Function(File file, T data);
 class RecordingFile extends RecordingFileSystemEntity<File> implements File {
   /// Creates a new `RecordingFile`.
   RecordingFile(RecordingFileSystem fileSystem, io.File delegate)
-      : super(fileSystem, delegate) {
+      : super(fileSystem as RecordingFileSystemImpl, delegate as File) {
     methods.addAll(<Symbol, Function>{
       #create: _create,
       #createSync: delegate.createSync,
@@ -93,7 +93,7 @@ class RecordingFile extends RecordingFileSystemEntity<File> implements File {
   StreamReference<Uint8List> _openRead([int start, int end]) {
     return _BlobStreamReference<Uint8List>(
       file: _newRecordingFile(),
-      stream: delegate.openRead(start, end),
+      stream: delegate.openRead(start, end).cast<Uint8List>(),
       writer: (File file, Uint8List bytes) {
         file.writeAsBytesSync(bytes, mode: FileMode.append, flush: true);
       },

--- a/packages/file/lib/src/backends/record_replay/recording_io_sink.dart
+++ b/packages/file/lib/src/backends/record_replay/recording_io_sink.dart
@@ -50,7 +50,7 @@ class RecordingIOSink extends Object
   String get identifier => '$runtimeType@$uid';
 
   @override
-  MutableRecording get recording => fileSystem.recording;
+  MutableRecording get recording => fileSystem.recording as MutableRecording;
 
   @override
   Stopwatch get stopwatch => fileSystem.stopwatch;

--- a/packages/file/lib/src/backends/record_replay/recording_link.dart
+++ b/packages/file/lib/src/backends/record_replay/recording_link.dart
@@ -15,7 +15,7 @@ import 'recording_file_system_entity.dart';
 class RecordingLink extends RecordingFileSystemEntity<Link> implements Link {
   /// Creates a new `RecordingLink`.
   RecordingLink(RecordingFileSystem fileSystem, io.Link delegate)
-      : super(fileSystem, delegate) {
+      : super(fileSystem as RecordingFileSystemImpl, delegate as Link) {
     methods.addAll(<Symbol, Function>{
       #create: _create,
       #createSync: delegate.createSync,

--- a/packages/file/lib/src/backends/record_replay/recording_proxy_mixin.dart
+++ b/packages/file/lib/src/backends/record_replay/recording_proxy_mixin.dart
@@ -90,12 +90,6 @@ mixin RecordingProxyMixin on Object implements ProxyObject, ReplayAware {
   @protected
   Stopwatch get stopwatch;
 
-  // This check is used in noSuchMethod to detect if this code is running in a
-  // Dart 1 runtime, or Dart 2.
-  // TODO(srawlins): Remove this after the minimum SDK constraint is such that
-  // there is no "Dart 1" runtime mode. 2.0.0 or something.
-  bool get _runningDart1Runtime => <dynamic>[] is List<String>;
-
   /// Handles invocations for which there is no concrete implementation
   /// function.
   ///
@@ -137,7 +131,7 @@ mixin RecordingProxyMixin on Object implements ProxyObject, ReplayAware {
     try {
       value = Function.apply(method, args, namedArgs);
     } catch (error) {
-      recording.add(createEvent(error: error));
+      recording.add(createEvent(error: error) as LiveInvocationEvent<dynamic>);
       rethrow;
     }
 
@@ -146,45 +140,43 @@ mixin RecordingProxyMixin on Object implements ProxyObject, ReplayAware {
     // We have to instantiate the correct type of StreamReference or
     // FutureReference, so that types are not lost when we unwrap the references
     // afterward.
-    if (_runningDart1Runtime && value is Stream<dynamic>) {
-      // This one is here for Dart 1 runtime mode.
-      value = StreamReference<dynamic>(value);
-    } else if (value is Stream<FileSystemEntity>) {
-      value = StreamReference<FileSystemEntity>(value);
+    if (value is Stream<FileSystemEntity>) {
+      value =
+          StreamReference<FileSystemEntity>(value as Stream<FileSystemEntity>);
     } else if (value is Stream<String>) {
-      value = StreamReference<String>(value);
+      value = StreamReference<String>(value as Stream<String>);
     } else if (value is Stream) {
       throw UnimplementedError(
           'Cannot record method with return type ${value.runtimeType}');
-    } else if (_runningDart1Runtime && value is Future<dynamic>) {
-      // This one is here for Dart 1 runtime mode.
-      value = FutureReference<dynamic>(value);
     } else if (value is Future<bool>) {
-      value = FutureReference<bool>(value);
+      value = FutureReference<bool>(value as Future<bool>);
     } else if (value is Future<Directory>) {
-      value = FutureReference<Directory>(value);
+      value = FutureReference<Directory>(value as Future<Directory>);
     } else if (value is Future<File>) {
-      value = FutureReference<File>(value);
+      value = FutureReference<File>(value as Future<File>);
     } else if (value is Future<FileNode>) {
-      value = FutureReference<FileNode>(value);
+      value = FutureReference<FileNode>(value as Future<FileNode>);
     } else if (value is Future<FileStat>) {
-      value = FutureReference<FileStat>(value);
+      value = FutureReference<FileStat>(value as Future<FileStat>);
     } else if (value is Future<Link>) {
-      value = FutureReference<Link>(value);
+      value = FutureReference<Link>(value as Future<Link>);
     } else if (value is Future<FileSystemEntity>) {
-      value = FutureReference<FileSystemEntity>(value);
+      value =
+          FutureReference<FileSystemEntity>(value as Future<FileSystemEntity>);
     } else if (value is Future<FileSystemEntityType>) {
-      value = FutureReference<FileSystemEntityType>(value);
+      value = FutureReference<FileSystemEntityType>(
+          value as Future<FileSystemEntityType>);
     } else if (value is Future<String>) {
-      value = FutureReference<String>(value);
+      value = FutureReference<String>(value as Future<String>);
     } else if (value is Future<RandomAccessFile>) {
-      value = FutureReference<RandomAccessFile>(value);
+      value =
+          FutureReference<RandomAccessFile>(value as Future<RandomAccessFile>);
     } else if (value is Future<void>) {
-      value = FutureReference<void>(value);
+      value = FutureReference<void>(value as Future<void>);
     }
 
     // Record the invocation event associated with this invocation.
-    recording.add(createEvent(result: value));
+    recording.add(createEvent(result: value) as LiveInvocationEvent<dynamic>);
 
     // Unwrap any result references before returning to the caller.
     dynamic result = value;

--- a/packages/file/lib/src/backends/record_replay/recording_random_access_file.dart
+++ b/packages/file/lib/src/backends/record_replay/recording_random_access_file.dart
@@ -69,7 +69,7 @@ class RecordingRandomAccessFile extends Object
   String get identifier => '$runtimeType@$uid';
 
   @override
-  MutableRecording get recording => fileSystem.recording;
+  MutableRecording get recording => fileSystem.recording as MutableRecording;
 
   @override
   Stopwatch get stopwatch => fileSystem.stopwatch;

--- a/packages/file/lib/src/backends/record_replay/replay_file_stat.dart
+++ b/packages/file/lib/src/backends/record_replay/replay_file_stat.dart
@@ -16,24 +16,27 @@ class ReplayFileStat implements FileStat {
   final Map<String, dynamic> _data;
 
   @override
-  DateTime get changed => DateTimeCodec.deserialize.convert(_data['changed']);
+  DateTime get changed =>
+      DateTimeCodec.deserialize.convert(_data['changed'] as int);
 
   @override
-  DateTime get modified => DateTimeCodec.deserialize.convert(_data['modified']);
+  DateTime get modified =>
+      DateTimeCodec.deserialize.convert(_data['modified'] as int);
 
   @override
-  DateTime get accessed => DateTimeCodec.deserialize.convert(_data['accessed']);
+  DateTime get accessed =>
+      DateTimeCodec.deserialize.convert(_data['accessed'] as int);
 
   @override
   FileSystemEntityType get type =>
-      EntityTypeCodec.deserialize.convert(_data['type']);
+      EntityTypeCodec.deserialize.convert(_data['type'] as String);
 
   @override
-  int get mode => _data['mode'];
+  int get mode => _data['mode'] as int;
 
   @override
-  int get size => _data['size'];
+  int get size => _data['size'] as int;
 
   @override
-  String modeString() => _data['modeString'];
+  String modeString() => _data['modeString'] as String;
 }

--- a/packages/file/lib/src/backends/record_replay/replay_file_system.dart
+++ b/packages/file/lib/src/backends/record_replay/replay_file_system.dart
@@ -75,8 +75,8 @@ abstract class ReplayFileSystem extends FileSystem {
     if (!manifestFile.existsSync()) {
       throw ArgumentError('Not a valid recording directory: $dirname');
     }
-    List<Map<String, dynamic>> manifest = const JsonDecoder()
-        .convert(manifestFile.readAsStringSync())
+    List<Map<String, dynamic>> manifest = (const JsonDecoder()
+            .convert(manifestFile.readAsStringSync()) as List<dynamic>)
         .cast<Map<String, dynamic>>();
     return ReplayFileSystemImpl(recording, manifest);
   }

--- a/packages/file/lib/src/backends/record_replay/replay_io_sink.dart
+++ b/packages/file/lib/src/backends/record_replay/replay_io_sink.dart
@@ -46,8 +46,9 @@ class ReplayIOSink extends Object with ReplayProxyMixin implements IOSink {
   @override
   dynamic onResult(Invocation invocation, dynamic result) {
     if (invocation.memberName == #addStream) {
-      Stream<List<int>> stream = invocation.positionalArguments.first;
-      Future<dynamic> future = result;
+      Stream<List<int>> stream =
+          invocation.positionalArguments.first as Stream<List<int>>;
+      Future<dynamic> future = result as Future<dynamic>;
       return future.then<void>(stream.drain);
     }
     return result;

--- a/packages/file/lib/src/backends/record_replay/replay_proxy_mixin.dart
+++ b/packages/file/lib/src/backends/record_replay/replay_proxy_mixin.dart
@@ -146,8 +146,10 @@ mixin ReplayProxyMixin on Object implements ProxyObject, ReplayAware {
 
   _InvocationMatcher _getMatcher(Invocation invocation) {
     String name = getSymbolName(invocation.memberName);
-    List<dynamic> args = encode(invocation.positionalArguments);
-    Map<String, dynamic> namedArgs = encode(invocation.namedArguments);
+    List<dynamic> args =
+        encode(invocation.positionalArguments) as List<dynamic>;
+    Map<String, dynamic> namedArgs =
+        encode(invocation.namedArguments) as Map<String, dynamic>;
 
     if (invocation.isGetter) {
       return (Map<String, dynamic> entry) =>
@@ -165,7 +167,9 @@ mixin ReplayProxyMixin on Object implements ProxyObject, ReplayAware {
         return entry[kManifestTypeKey] == kInvokeType &&
             entry[kManifestMethodKey] == name &&
             deeplyEqual(entry[kManifestPositionalArgumentsKey], args) &&
-            deeplyEqual(_asNamedArgsType(entry[kManifestNamedArgumentsKey]),
+            deeplyEqual(
+                _asNamedArgsType(
+                    entry[kManifestNamedArgumentsKey] as Map<String, dynamic>),
                 namedArgs) &&
             entry[kManifestObjectKey] == identifier;
       };

--- a/packages/file/lib/src/forwarding/forwarding_directory.dart
+++ b/packages/file/lib/src/forwarding/forwarding_directory.dart
@@ -11,7 +11,7 @@ import 'package:file/file.dart';
 abstract class ForwardingDirectory<T extends Directory>
     implements ForwardingFileSystemEntity<T, io.Directory>, Directory {
   @override
-  T wrap(io.Directory delegate) => wrapDirectory(delegate);
+  T wrap(io.Directory delegate) => wrapDirectory(delegate) as T;
 
   @override
   Future<Directory> create({bool recursive = false}) async =>

--- a/packages/file/lib/src/forwarding/forwarding_file.dart
+++ b/packages/file/lib/src/forwarding/forwarding_file.dart
@@ -13,7 +13,7 @@ import 'package:file/file.dart';
 abstract class ForwardingFile
     implements ForwardingFileSystemEntity<File, io.File>, File {
   @override
-  ForwardingFile wrap(io.File delegate) => wrapFile(delegate);
+  ForwardingFile wrap(io.File delegate) => wrapFile(delegate) as ForwardingFile;
 
   @override
   Future<File> create({bool recursive = false}) async =>

--- a/packages/file/lib/src/forwarding/forwarding_link.dart
+++ b/packages/file/lib/src/forwarding/forwarding_link.dart
@@ -11,7 +11,7 @@ import 'package:file/file.dart';
 abstract class ForwardingLink
     implements ForwardingFileSystemEntity<Link, io.Link>, Link {
   @override
-  ForwardingLink wrap(io.Link delegate) => wrapLink(delegate);
+  ForwardingLink wrap(io.Link delegate) => wrapLink(delegate) as ForwardingLink;
 
   @override
   Future<Link> create(String target, {bool recursive = false}) async =>

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -13,7 +13,6 @@ description:
 homepage: https://github.com/google/file.dart
 
 dependencies:
-  intl: '>=0.14.0 <1.0.0'
   meta: ^1.1.2
   path: ^1.5.1
 

--- a/packages/file/test/chroot_test.dart
+++ b/packages/file/test/chroot_test.dart
@@ -67,7 +67,7 @@ void main() {
 
       setUp(() {
         fs = createMemoryBackedChrootFileSystem();
-        mem = fs.delegate;
+        mem = fs.delegate as MemoryFileSystem;
       });
 
       group('FileSystem', () {

--- a/packages/file/test/common_tests.dart
+++ b/packages/file/test/common_tests.dart
@@ -144,7 +144,7 @@ void runCommonTests(
 
     setUp(() async {
       root = rootfn != null ? rootfn() : '/';
-      fs = await createFs();
+      fs = await createFs() as FileSystem;
       assert(fs.path.isAbsolute(root));
       assert(!root.endsWith(fs.path.separator) ||
           fs.path.rootPrefix(root) == root);

--- a/packages/file/test/record_replay_matchers.dart
+++ b/packages/file/test/record_replay_matchers.dart
@@ -72,7 +72,7 @@ abstract class RecordedInvocation<T extends RecordedInvocation<T>>
   /// Returns this matcher for chaining.
   T on(dynamic object) {
     _fieldMatchers.add(_Target(object));
-    return this;
+    return this as T;
   }
 
   /// Limits the scope of the match to invocations that produced the specified
@@ -90,7 +90,7 @@ abstract class RecordedInvocation<T extends RecordedInvocation<T>>
   /// Returns this matcher for chaining.
   T withResult(dynamic result) {
     _fieldMatchers.add(_Result(result));
-    return this;
+    return this as T;
   }
 
   /// Limits the scope of the match to invocations that were recorded with the
@@ -102,7 +102,7 @@ abstract class RecordedInvocation<T extends RecordedInvocation<T>>
   /// Returns this matcher for chaining.
   T withTimestamp(dynamic timestamp) {
     _fieldMatchers.add(_Timestamp(timestamp));
-    return this;
+    return this as T;
   }
 
   /// @nodoc
@@ -129,8 +129,9 @@ abstract class RecordedInvocation<T extends RecordedInvocation<T>>
     Map<dynamic, dynamic> matchState,
     bool verbose,
   ) {
-    Matcher matcher = matchState['matcher'];
-    matcher.describeMismatch(item, description, matchState['state'], verbose);
+    Matcher matcher = matchState['matcher'] as Matcher;
+    matcher.describeMismatch(item, description,
+        matchState['state'] as Map<String, dynamic>, verbose);
     return description;
   }
 
@@ -369,7 +370,7 @@ class _MethodName extends Matcher {
 
   @override
   bool matches(dynamic item, Map<dynamic, dynamic> matchState) =>
-      _matcher.matches(getSymbolName(item.method), matchState);
+      _matcher.matches(getSymbolName(item.method as Symbol), matchState);
 
   @override
   Description describeMismatch(
@@ -378,7 +379,7 @@ class _MethodName extends Matcher {
     Map<dynamic, dynamic> matchState,
     bool verbose,
   ) {
-    String methodName = getSymbolName(item.method);
+    String methodName = getSymbolName(item.method as Symbol);
     description.add('invoked method: \'$methodName\'');
     Description matcherDesc = StringDescription();
     _matcher.describeMismatch(methodName, matcherDesc, matchState, verbose);
@@ -482,7 +483,7 @@ class _GetPropertyName extends Matcher {
 
   @override
   bool matches(dynamic item, Map<dynamic, dynamic> matchState) =>
-      _matcher.matches(getSymbolName(item.property), matchState);
+      _matcher.matches(getSymbolName(item.property as Symbol), matchState);
 
   @override
   Description describeMismatch(
@@ -491,7 +492,7 @@ class _GetPropertyName extends Matcher {
     Map<dynamic, dynamic> matchState,
     bool verbose,
   ) {
-    String propertyName = getSymbolName(item.property);
+    String propertyName = getSymbolName(item.property as Symbol);
     description.add('got property: \'$propertyName\'');
     Description matcherDesc = StringDescription();
     _matcher.describeMismatch(propertyName, matcherDesc, matchState, verbose);
@@ -515,7 +516,7 @@ class _SetPropertyName extends Matcher {
 
   /// Strips the trailing `=` off the symbol name to get the property name.
   String _getPropertyName(dynamic item) {
-    String symbolName = getSymbolName(item.property);
+    String symbolName = getSymbolName(item.property as Symbol);
     return symbolName.substring(0, symbolName.length - 1);
   }
 

--- a/packages/file/test/recording_test.dart
+++ b/packages/file/test/recording_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
@@ -197,7 +198,8 @@ void main() {
         await rc.futureMethod('qux', namedArg: 'quz');
         await rc.streamMethod('quux', namedArg: 'quuz').drain<void>();
         List<Map<String, dynamic>> manifest =
-            await encode(recording.events).cast<Map<String, dynamic>>();
+            (await encode(recording.events) as List<dynamic>)
+                .cast<Map<String, dynamic>>();
         expect(manifest[0], <String, dynamic>{
           'type': 'set',
           'property': 'basicProperty=',
@@ -435,7 +437,7 @@ void main() {
             List<InvocationEvent<dynamic>> events = recording.events;
             expect(events.length, greaterThanOrEqualTo(2));
             expect(events[0], invokesMethod().withResult(isDirectory));
-            Directory directory = events[0].result;
+            Directory directory = events[0].result as Directory;
             expect(
                 events,
                 contains(setsProperty('currentDirectory')
@@ -624,7 +626,8 @@ void main() {
                 containsPair('namedArguments', isEmpty),
                 containsPair('result', matches(r'^![0-9]+.foo$')),
               ));
-          File file = _getRecordingFile(recording, manifest[1]['result']);
+          File file =
+              _getRecordingFile(recording, manifest[1]['result'] as String);
           expect(file, exists);
           expect(await file.readAsString(), content);
         });
@@ -654,7 +657,8 @@ void main() {
                 containsPair('namedArguments', isEmpty),
                 containsPair('result', matches(r'^![0-9]+.foo$')),
               ));
-          File file = _getRecordingFile(recording, manifest[1]['result']);
+          File file =
+              _getRecordingFile(recording, manifest[1]['result'] as String);
           expect(file, exists);
           expect(await file.readAsString(), content);
         });
@@ -682,7 +686,8 @@ void main() {
                 containsPair('namedArguments', isEmpty),
                 containsPair('result', matches(r'^![0-9]+.foo$')),
               ));
-          File file = _getRecordingFile(recording, manifest[1]['result']);
+          File file =
+              _getRecordingFile(recording, manifest[1]['result'] as String);
           expect(file, exists);
           expect(await file.readAsString(), content);
         });
@@ -717,7 +722,8 @@ void main() {
                       containsPair('encoding', 'iso-8859-1'),
                     )),
               ));
-          File file = _getRecordingFile(recording, manifest[1]['result']);
+          File file =
+              _getRecordingFile(recording, manifest[1]['result'] as String);
           expect(file, exists);
           expect(await file.readAsString(), content);
         });
@@ -752,7 +758,8 @@ void main() {
                       containsPair('encoding', 'iso-8859-1'),
                     )),
               ));
-          File file = _getRecordingFile(recording, manifest[1]['result']);
+          File file =
+              _getRecordingFile(recording, manifest[1]['result'] as String);
           expect(file, exists);
           expect(await file.readAsString(), content);
         });
@@ -783,7 +790,8 @@ void main() {
                 containsPair(
                     'namedArguments', <String, String>{'encoding': 'utf-8'}),
               ));
-          File file = _getRecordingFile(recording, manifest[1]['result']);
+          File file =
+              _getRecordingFile(recording, manifest[1]['result'] as String);
           expect(file, exists);
           expect(await file.readAsString(), content);
         });
@@ -814,7 +822,8 @@ void main() {
                 containsPair(
                     'namedArguments', <String, String>{'encoding': 'utf-8'}),
               ));
-          File file = _getRecordingFile(recording, manifest[1]['result']);
+          File file =
+              _getRecordingFile(recording, manifest[1]['result'] as String);
           expect(file, exists);
           expect(await file.readAsString(), content);
         });
@@ -836,9 +845,9 @@ void main() {
 List<Map<String, dynamic>> _loadManifest(LiveRecording recording) {
   List<FileSystemEntity> files = recording.destination.listSync();
   File manifestFile = files.singleWhere(
-      (FileSystemEntity entity) => entity.basename == kManifestName);
-  return const JsonDecoder()
-      .convert(manifestFile.readAsStringSync())
+      (FileSystemEntity entity) => entity.basename == kManifestName) as File;
+  return (const JsonDecoder().convert(manifestFile.readAsStringSync())
+          as List<dynamic>)
       .cast<Map<String, dynamic>>();
 }
 


### PR DESCRIPTION
* Implicit dynamic is removed, which will make it easier to migrate to null-safety where it is not supported.
* Intl dependency is removed, since this will block null safety despite being used in only a single place.