### PR TITLE
Make ForwardingFile.openRead return Stream<List<int>> again

### DIFF
--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -1,8 +1,14 @@
+#### 6.0.0-nullsafety.2
+
+* Make `ForwardingFile.openRead`'s return type again match the return type from
+  `dart:io`.
+* Remove some unnecessary `Uint8List` conversions in `ForwardingFile`.
+
 #### 6.0.0-nullsafety.1
 
 * Update to null safety.
 * Remove record/replay functionality.
-* Made `MemoryRandomAccessFile` and `MemoryFile.openWrite` handle the file.
+* Made `MemoryRandomAccessFile` and `MemoryFile.openWrite` handle the file
   being removed or renamed while open.
 * Fixed incorrect formatting in `NoMatchingInvocationError.toString()`.
 * Fixed more test flakiness.

--- a/packages/file/lib/src/forwarding/forwarding_file.dart
+++ b/packages/file/lib/src/forwarding/forwarding_file.dart
@@ -64,7 +64,7 @@ abstract class ForwardingFile
   @override
   Future<RandomAccessFile> open({
     FileMode mode = FileMode.read,
-  }) async =>
+  }) =>
       delegate.open(mode: mode);
 
   @override
@@ -72,10 +72,8 @@ abstract class ForwardingFile
       delegate.openSync(mode: mode);
 
   @override
-  Stream<Uint8List> openRead([int? start, int? end]) => delegate
-      .openRead(start, end)
-      .cast<List<int>>()
-      .transform(const _ToUint8List());
+  Stream<List<int>> openRead([int? start, int? end]) =>
+      delegate.openRead(start, end);
 
   @override
   IOSink openWrite({
@@ -85,14 +83,10 @@ abstract class ForwardingFile
       delegate.openWrite(mode: mode, encoding: encoding);
 
   @override
-  Future<Uint8List> readAsBytes() {
-    return delegate.readAsBytes().then<Uint8List>((List<int> bytes) {
-      return Uint8List.fromList(bytes);
-    });
-  }
+  Future<Uint8List> readAsBytes() => delegate.readAsBytes();
 
   @override
-  Uint8List readAsBytesSync() => Uint8List.fromList(delegate.readAsBytesSync());
+  Uint8List readAsBytesSync() => delegate.readAsBytesSync();
 
   @override
   Future<String> readAsString({Encoding encoding = utf8}) =>
@@ -157,32 +151,4 @@ abstract class ForwardingFile
         encoding: encoding,
         flush: flush,
       );
-}
-
-class _ToUint8List extends Converter<List<int>, Uint8List> {
-  const _ToUint8List();
-
-  @override
-  Uint8List convert(List<int> input) => Uint8List.fromList(input);
-
-  @override
-  Sink<List<int>> startChunkedConversion(Sink<Uint8List> sink) {
-    return _Uint8ListConversionSink(sink);
-  }
-}
-
-class _Uint8ListConversionSink implements Sink<List<int>> {
-  const _Uint8ListConversionSink(this._target);
-
-  final Sink<Uint8List> _target;
-
-  @override
-  void add(List<int> data) {
-    _target.add(Uint8List.fromList(data));
-  }
-
-  @override
-  void close() {
-    _target.close();
-  }
 }

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 6.0.0-nullsafety.1
+version: 6.0.0-nullsafety.2
 description:
   A pluggable, mockable file system abstraction for Dart. Supports local file
   system access, as well as in-memory file systems, record-replay file systems,


### PR DESCRIPTION
`ForwardingFile.openRead` was changed to return a `Stream<Uint8List>`
instead of a `Stream<List<int>>` in preparation for making a
corresponding change to `dart:io`.  However, that `dart:io` change
caused more breakage than expected and was reverted without making
corresponding reverts to `package:file`.  I don't think that it makes
sense for `ForwardingFile` to return something different than its
delegate.

Without this change, the following code will fail with `package:file`
but not with `dart:io`:

```dart
await someFile.openRead().transform(utf8.decoder);
```

and unintuitively requires adding `.cast<List<int>>()` before
the transformation.

Bonus cleanup: since dart:io's `File.readAsBytes`/`readAsBytesSync`
are declared to return `Uint8List`, `ForwardingFile` should no longer
need to make explicit `Uint8List` copies.