### PR TITLE
Remove unused dart:async imports.

### DIFF
--- a/packages/file/lib/src/backends/chroot.dart
+++ b/packages/file/lib/src/backends/chroot.dart
@@ -4,7 +4,6 @@
 
 library file.src.backends.chroot;
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 

--- a/packages/file/lib/src/backends/local/local_file_system.dart
+++ b/packages/file/lib/src/backends/local/local_file_system.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 import 'package:path/path.dart' as p;

--- a/packages/file/lib/src/backends/memory/memory_directory.dart
+++ b/packages/file/lib/src/backends/memory/memory_directory.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:file/file.dart';
 import 'package:file/src/common.dart' as common;
 import 'package:file/src/io.dart' as io;

--- a/packages/file/lib/src/backends/memory/memory_file_system.dart
+++ b/packages/file/lib/src/backends/memory/memory_file_system.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:file/file.dart';
 import 'package:file/src/io.dart' as io;
 import 'package:path/path.dart' as p;

--- a/packages/file/lib/src/backends/memory/memory_file_system_entity.dart
+++ b/packages/file/lib/src/backends/memory/memory_file_system_entity.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:file/file.dart';
 import 'package:file/src/common.dart' as common;
 import 'package:file/src/io.dart' as io;

--- a/packages/file/lib/src/backends/memory/memory_link.dart
+++ b/packages/file/lib/src/backends/memory/memory_link.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:file/file.dart';
 import 'package:file/src/common.dart' as common;
 import 'package:file/src/io.dart' as io;

--- a/packages/file/lib/src/forwarding/forwarding_directory.dart
+++ b/packages/file/lib/src/forwarding/forwarding_directory.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 

--- a/packages/file/lib/src/forwarding/forwarding_file.dart
+++ b/packages/file/lib/src/forwarding/forwarding_file.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 

--- a/packages/file/lib/src/forwarding/forwarding_file_system.dart
+++ b/packages/file/lib/src/forwarding/forwarding_file_system.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 import 'package:meta/meta.dart';

--- a/packages/file/lib/src/forwarding/forwarding_file_system_entity.dart
+++ b/packages/file/lib/src/forwarding/forwarding_file_system_entity.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 import 'package:meta/meta.dart';

--- a/packages/file/lib/src/forwarding/forwarding_link.dart
+++ b/packages/file/lib/src/forwarding/forwarding_link.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 

--- a/packages/file/lib/src/interface/directory.dart
+++ b/packages/file/lib/src/interface/directory.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import '../io.dart' as io;
 
 import 'file.dart';

--- a/packages/file/lib/src/interface/file.dart
+++ b/packages/file/lib/src/interface/file.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 
 import '../io.dart' as io;

--- a/packages/file/lib/src/interface/file_system.dart
+++ b/packages/file/lib/src/interface/file_system.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 

--- a/packages/file/lib/src/interface/file_system_entity.dart
+++ b/packages/file/lib/src/interface/file_system_entity.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import '../io.dart' as io;
 
 import 'directory.dart';

--- a/packages/file/lib/src/interface/link.dart
+++ b/packages/file/lib/src/interface/link.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import '../io.dart' as io;
 
 import 'file_system_entity.dart';


### PR DESCRIPTION
Since this package doesn't support Dart 2.0, Future/Stream are always
exported from dart:core.