### PR TITLE
migrate file_testing to null safety

### DIFF
--- a/packages/file_testing/CHANGELOG.md
+++ b/packages/file_testing/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 3.0.0
+
+* Migrate to null safety.
+
 #### 2.2.0
 
 * Change dependency on `package:test_api` back to `package:test`.

--- a/packages/file_testing/lib/src/testing/core_matchers.dart
+++ b/packages/file_testing/lib/src/testing/core_matchers.dart
@@ -73,9 +73,9 @@ class _FileSystemException extends Matcher {
   _FileSystemException(dynamic osErrorCode)
       : _matcher = _wrapMatcher(osErrorCode);
 
-  final Matcher _matcher;
+  final Matcher? _matcher;
 
-  static Matcher _wrapMatcher(dynamic osErrorCode) {
+  static Matcher? _wrapMatcher(dynamic osErrorCode) {
     if (osErrorCode == null) {
       return null;
     }
@@ -86,7 +86,7 @@ class _FileSystemException extends Matcher {
   bool matches(dynamic item, Map<dynamic, dynamic> matchState) {
     if (item is FileSystemException) {
       return _matcher == null ||
-          _matcher.matches(item.osError?.errorCode, matchState);
+          _matcher!.matches(item.osError?.errorCode, matchState);
     }
     return false;
   }
@@ -97,7 +97,7 @@ class _FileSystemException extends Matcher {
       return desc.add('FileSystemException');
     } else {
       desc.add('FileSystemException with osError.errorCode: ');
-      return _matcher.describe(desc);
+      return _matcher!.describe(desc);
     }
   }
 }

--- a/packages/file_testing/lib/src/testing/internal.dart
+++ b/packages/file_testing/lib/src/testing/internal.dart
@@ -2,8 +2,5 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:meta/meta.dart';
-
 /// True if we should ignore OS error codes in our matchers.
-@visibleForTesting
 bool ignoreOsErrorCodes = false;

--- a/packages/file_testing/pubspec.yaml
+++ b/packages/file_testing/pubspec.yaml
@@ -1,13 +1,10 @@
 name: file_testing
-version: 2.2.0
-authors:
-- Todd Volkert <tvolkert@google.com>
+version: 3.0.0
 description: Testing utilities for package:file
 homepage: https://github.com/google/file.dart/packages/file_testing
 
-dependencies:
-  meta: ^1.1.2
-  test: ^1.0.0
-
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
+
+dependencies:
+  test: ^1.16.0


### PR DESCRIPTION
As it says. no changes, but removed extra usage of meta