### PR TITLE
Add ophandle for FileSystemEntity.exists/existsSync

### DIFF
--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### 6.1.1
 
-* `MemoryFileSystem` now provides `opHandle`s for copy and open operations.
+* `MemoryFile` now provides `opHandle`s for copy and open operations.
 
 #### 6.1.0
 

--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -1,6 +1,10 @@
+#### 6.1.2
+
+* `MemoryFileSystem` now provides `opHandle`s for exists operations.
+
 #### 6.1.1
 
-* `MemoryFile` now provides `opHandle`s for copy and open operations.
+* `MemoryFileSystem` now provides `opHandle`s for copy and open operations.
 
 #### 6.1.0
 

--- a/packages/file/lib/src/backends/memory/memory_directory.dart
+++ b/packages/file/lib/src/backends/memory/memory_directory.dart
@@ -38,7 +38,10 @@ class MemoryDirectory extends MemoryFileSystemEntity
   }
 
   @override
-  bool existsSync() => backingOrNull?.stat.type == expectedType;
+  bool existsSync() {
+    fileSystem.opHandle.call(path, FileSystemOp.exists);
+    return backingOrNull?.stat.type == expectedType;
+  }
 
   @override
   Future<Directory> create({bool recursive = false}) async {

--- a/packages/file/lib/src/backends/memory/memory_file.dart
+++ b/packages/file/lib/src/backends/memory/memory_file.dart
@@ -42,7 +42,10 @@ class MemoryFile extends MemoryFileSystemEntity implements File {
   io.FileSystemEntityType get expectedType => io.FileSystemEntityType.file;
 
   @override
-  bool existsSync() => backingOrNull?.stat.type == expectedType;
+  bool existsSync() {
+    fileSystem.opHandle.call(path, FileSystemOp.exists);
+    return backingOrNull?.stat.type == expectedType;
+  }
 
   @override
   Future<File> create({bool recursive = false}) async {

--- a/packages/file/lib/src/backends/memory/memory_link.dart
+++ b/packages/file/lib/src/backends/memory/memory_link.dart
@@ -22,7 +22,10 @@ class MemoryLink extends MemoryFileSystemEntity implements Link {
   io.FileSystemEntityType get expectedType => io.FileSystemEntityType.link;
 
   @override
-  bool existsSync() => backingOrNull?.type == expectedType;
+  bool existsSync() {
+    fileSystem.opHandle.call(path, FileSystemOp.exists);
+    return backingOrNull?.type == expectedType;
+  }
 
   @override
   Future<Link> rename(String newPath) async => renameSync(newPath);

--- a/packages/file/lib/src/backends/memory/operations.dart
+++ b/packages/file/lib/src/backends/memory/operations.dart
@@ -56,7 +56,7 @@ class FileSystemOp {
   /// * [File.copySync]
   static const FileSystemOp copy = FileSystemOp._(5);
 
-  /// A file  system operation used for all exists methods.
+  /// A file system operation used for all exists methods.
   ///
   /// * [FileSystemEntity.exists]
   /// * [FileSystemEntity.existsSync]

--- a/packages/file/lib/src/backends/memory/operations.dart
+++ b/packages/file/lib/src/backends/memory/operations.dart
@@ -56,6 +56,12 @@ class FileSystemOp {
   /// * [File.copySync]
   static const FileSystemOp copy = FileSystemOp._(5);
 
+  /// A file  system operation used for all exists methods.
+  ///
+  /// * [FileSystemEntity.exists]
+  /// * [FileSystemEntity.existsSync]
+  static const FileSystemOp exists = FileSystemOp._(6);
+
   @override
   String toString() {
     switch (_value) {
@@ -71,6 +77,8 @@ class FileSystemOp {
         return 'FileSystemOp.open';
       case 5:
         return 'FileSystemOp.copy';
+      case 6:
+        return 'FileSystemOp.exists';
       default:
         throw StateError('Invalid FileSytemOp type: $this');
     }

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 6.1.1
+version: 6.1.2
 description:
   A pluggable, mockable file system abstraction for Dart. Supports local file
   system access, as well as in-memory file systems, record-replay file systems,
@@ -7,7 +7,7 @@ description:
 homepage: https://github.com/google/file.dart
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   meta: ^1.3.0

--- a/packages/file/test/memory_operations_test.dart
+++ b/packages/file/test/memory_operations_test.dart
@@ -192,7 +192,7 @@ void main() {
     List<FileSystemOp> operations = <FileSystemOp>[];
     MemoryFileSystem fs = MemoryFileSystem.test(
         opHandle: (String context, FileSystemOp operation) {
-      if (operation == FileSystemOp.create) {
+      if (operation == FileSystemOp.exists) {
         contexts.add(context);
         operations.add(operation);
       }

--- a/packages/file/test/memory_operations_test.dart
+++ b/packages/file/test/memory_operations_test.dart
@@ -187,10 +187,46 @@ void main() {
     ]);
   });
 
+  test('Exists operations invoke opHandle', () async {
+    List<String> contexts = <String>[];
+    List<FileSystemOp> operations = <FileSystemOp>[];
+    MemoryFileSystem fs = MemoryFileSystem.test(
+        opHandle: (String context, FileSystemOp operation) {
+      if (operation == FileSystemOp.create) {
+        contexts.add(context);
+        operations.add(operation);
+      }
+    });
+    fs.file('testA').existsSync();
+    await fs.file('testB').exists();
+    fs.directory('testDirA').existsSync();
+    await fs.directory('testDirB').exists();
+    fs.link('testLinkA').existsSync();
+    await fs.link('testLinkB').exists();
+
+    expect(contexts, <dynamic>[
+      'testA',
+      'testB',
+      'testDirA',
+      'testDirB',
+      'testLinkA',
+      'testLinkB',
+    ]);
+    expect(operations, <FileSystemOp>[
+      FileSystemOp.exists,
+      FileSystemOp.exists,
+      FileSystemOp.exists,
+      FileSystemOp.exists,
+      FileSystemOp.exists,
+      FileSystemOp.exists,
+    ]);
+  });
+
   test('FileSystemOp toString', () {
     expect(FileSystemOp.create.toString(), 'FileSystemOp.create');
     expect(FileSystemOp.delete.toString(), 'FileSystemOp.delete');
     expect(FileSystemOp.read.toString(), 'FileSystemOp.read');
     expect(FileSystemOp.write.toString(), 'FileSystemOp.write');
+    expect(FileSystemOp.exists.toString(), 'FileSystemOp.exists');
   });
 }


### PR DESCRIPTION
Can remove most of the rest of error_handling_io's mocks