### PR TITLE
skip a failing test on windows

### DIFF
--- a/packages/file/test/common_tests.dart
+++ b/packages/file/test/common_tests.dart
@@ -637,13 +637,18 @@ void runCommonTests(
           expect(dest, exists);
         });
 
-        test('succeedsIfDestinationIsEmptyDirectory', () {
-          fs.directory(ns('/bar')).createSync();
-          Directory src = fs.directory(ns('/foo'))..createSync();
-          Directory dest = src.renameSync(ns('/bar'));
-          expect(src, isNot(exists));
-          expect(dest, exists);
-        });
+        test(
+          'succeedsIfDestinationIsEmptyDirectory',
+          () {
+            fs.directory(ns('/bar')).createSync();
+            Directory src = fs.directory(ns('/foo'))..createSync();
+            Directory dest = src.renameSync(ns('/bar'));
+            expect(src, isNot(exists));
+            expect(dest, exists);
+          },
+          // See https://github.com/google/file.dart/issues/197.
+          skip: io.Platform.isWindows,
+        );
 
         test('throwsIfDestinationIsFile', () {
           fs.file(ns('/bar')).createSync();


### PR DESCRIPTION
This PR skips a failing test on windows. The test has been failing for a while now, and we're not getting coverage from the CI due to the failure.

- skip a failing test on windows (`succeedsIfDestinationIsEmptyDirectory`)
- tracking the failure in https://github.com/google/file.dart/issues/197
