### PR TITLE
Migrate to Dart 3

### DIFF
--- a/.github/workflows/file.yml
+++ b/.github/workflows/file.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         package: [file]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [stable, beta, dev]
+        sdk: [dev]
 
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c

--- a/.github/workflows/file.yml
+++ b/.github/workflows/file.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         package: [file]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [dev]
+        sdk: [stable, dev]
 
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c

--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 7.0.0
+* Dart 3 fixes for class modifiers.
+
 #### 6.1.4
 
 * Populate the pubspec `repository` field.

--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -1,4 +1,4 @@
-#### 7.0.0
+#### 7.0.0-wip
 
 * Dart 3 fixes for class modifiers.
 

--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -1,4 +1,5 @@
-#### 6.2.0
+#### 7.0.0
+
 * Dart 3 fixes for class modifiers.
 
 #### 6.1.4

--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -1,4 +1,4 @@
-#### 7.0.0
+#### 6.2.0
 * Dart 3 fixes for class modifiers.
 
 #### 6.1.4

--- a/packages/file/lib/src/backends/memory/memory_directory.dart
+++ b/packages/file/lib/src/backends/memory/memory_directory.dart
@@ -74,19 +74,19 @@ class MemoryDirectory extends MemoryFileSystemEntity
 
   @override
   Directory createTempSync([String? prefix]) {
-    prefix = (prefix ?? '') + 'rand';
+    prefix = '${prefix ?? ''}rand';
     String fullPath = fileSystem.path.join(path, prefix);
     String dirname = fileSystem.path.dirname(fullPath);
     String basename = fileSystem.path.basename(fullPath);
     DirectoryNode? node = fileSystem.findNode(dirname) as DirectoryNode?;
     checkExists(node, () => dirname);
     utils.checkIsDir(node!, () => dirname);
-    int _tempCounter = _systemTempCounter[fileSystem] ?? 0;
-    String name() => '$basename$_tempCounter';
+    int tempCounter = _systemTempCounter[fileSystem] ?? 0;
+    String name() => '$basename$tempCounter';
     while (node.children.containsKey(name())) {
-      _tempCounter++;
+      tempCounter++;
     }
-    _systemTempCounter[fileSystem] = _tempCounter;
+    _systemTempCounter[fileSystem] = tempCounter;
     DirectoryNode tempDir = DirectoryNode(node);
     node.children[name()] = tempDir;
     return MemoryDirectory(fileSystem, fileSystem.path.join(dirname, name()))

--- a/packages/file/lib/src/backends/memory/memory_file.dart
+++ b/packages/file/lib/src/backends/memory/memory_file.dart
@@ -359,7 +359,7 @@ class _FileSink implements io.IOSink {
     return _FileSink._(future, encoding);
   }
 
-  _FileSink._(Future<FileNode> _node, this.encoding) : _pendingWrites = _node;
+  _FileSink._(Future<FileNode> node, this.encoding) : _pendingWrites = node;
 
   final Completer<void> _completer = Completer<void>();
 

--- a/packages/file/lib/src/common.dart
+++ b/packages/file/lib/src/common.dart
@@ -52,7 +52,7 @@ FileSystemException _fsException(String path, String msg, int errorCode) {
 
 /// Mixin containing implementations of [Directory] methods that are common
 /// to all implementations.
-abstract class DirectoryAddOnsMixin implements Directory {
+mixin DirectoryAddOnsMixin implements Directory {
   @override
   Directory childDirectory(String basename) {
     return fileSystem.directory(fileSystem.path.join(path, basename));

--- a/packages/file/lib/src/common.dart
+++ b/packages/file/lib/src/common.dart
@@ -52,7 +52,7 @@ FileSystemException _fsException(String path, String msg, int errorCode) {
 
 /// Mixin containing implementations of [Directory] methods that are common
 /// to all implementations.
-abstract mixin class DirectoryAddOnsMixin implements Directory {
+mixin DirectoryAddOnsMixin implements Directory {
   @override
   Directory childDirectory(String basename) {
     return fileSystem.directory(fileSystem.path.join(path, basename));

--- a/packages/file/lib/src/common.dart
+++ b/packages/file/lib/src/common.dart
@@ -52,7 +52,7 @@ FileSystemException _fsException(String path, String msg, int errorCode) {
 
 /// Mixin containing implementations of [Directory] methods that are common
 /// to all implementations.
-mixin DirectoryAddOnsMixin implements Directory {
+abstract mixin class DirectoryAddOnsMixin implements Directory {
   @override
   Directory childDirectory(String basename) {
     return fileSystem.directory(fileSystem.path.join(path, basename));

--- a/packages/file/lib/src/forwarding/forwarding_directory.dart
+++ b/packages/file/lib/src/forwarding/forwarding_directory.dart
@@ -6,7 +6,7 @@ import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 
 /// A directory that forwards all methods and properties to a delegate.
-abstract class ForwardingDirectory<T extends Directory>
+mixin ForwardingDirectory<T extends Directory>
     implements ForwardingFileSystemEntity<T, io.Directory>, Directory {
   @override
   T wrap(io.Directory delegate) => wrapDirectory(delegate) as T;

--- a/packages/file/lib/src/forwarding/forwarding_directory.dart
+++ b/packages/file/lib/src/forwarding/forwarding_directory.dart
@@ -6,7 +6,7 @@ import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 
 /// A directory that forwards all methods and properties to a delegate.
-abstract mixin class ForwardingDirectory<T extends Directory>
+mixin ForwardingDirectory<T extends Directory>
     implements ForwardingFileSystemEntity<T, io.Directory>, Directory {
   @override
   T wrap(io.Directory delegate) => wrapDirectory(delegate) as T;

--- a/packages/file/lib/src/forwarding/forwarding_directory.dart
+++ b/packages/file/lib/src/forwarding/forwarding_directory.dart
@@ -6,7 +6,7 @@ import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 
 /// A directory that forwards all methods and properties to a delegate.
-mixin ForwardingDirectory<T extends Directory>
+abstract mixin class ForwardingDirectory<T extends Directory>
     implements ForwardingFileSystemEntity<T, io.Directory>, Directory {
   @override
   T wrap(io.Directory delegate) => wrapDirectory(delegate) as T;

--- a/packages/file/lib/src/forwarding/forwarding_file.dart
+++ b/packages/file/lib/src/forwarding/forwarding_file.dart
@@ -9,7 +9,7 @@ import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 
 /// A file that forwards all methods and properties to a delegate.
-abstract class ForwardingFile
+mixin ForwardingFile
     implements ForwardingFileSystemEntity<File, io.File>, File {
   @override
   ForwardingFile wrap(io.File delegate) => wrapFile(delegate) as ForwardingFile;

--- a/packages/file/lib/src/forwarding/forwarding_file.dart
+++ b/packages/file/lib/src/forwarding/forwarding_file.dart
@@ -9,7 +9,7 @@ import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 
 /// A file that forwards all methods and properties to a delegate.
-abstract mixin class ForwardingFile
+mixin ForwardingFile
     implements ForwardingFileSystemEntity<File, io.File>, File {
   @override
   ForwardingFile wrap(io.File delegate) => wrapFile(delegate) as ForwardingFile;

--- a/packages/file/lib/src/forwarding/forwarding_file.dart
+++ b/packages/file/lib/src/forwarding/forwarding_file.dart
@@ -9,7 +9,7 @@ import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 
 /// A file that forwards all methods and properties to a delegate.
-mixin ForwardingFile
+abstract mixin class ForwardingFile
     implements ForwardingFileSystemEntity<File, io.File>, File {
   @override
   ForwardingFile wrap(io.File delegate) => wrapFile(delegate) as ForwardingFile;

--- a/packages/file/lib/src/forwarding/forwarding_link.dart
+++ b/packages/file/lib/src/forwarding/forwarding_link.dart
@@ -6,7 +6,7 @@ import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 
 /// A link that forwards all methods and properties to a delegate.
-abstract mixin class ForwardingLink
+mixin ForwardingLink
     implements ForwardingFileSystemEntity<Link, io.Link>, Link {
   @override
   ForwardingLink wrap(io.Link delegate) => wrapLink(delegate) as ForwardingLink;

--- a/packages/file/lib/src/forwarding/forwarding_link.dart
+++ b/packages/file/lib/src/forwarding/forwarding_link.dart
@@ -6,7 +6,7 @@ import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 
 /// A link that forwards all methods and properties to a delegate.
-mixin ForwardingLink
+abstract mixin class ForwardingLink
     implements ForwardingFileSystemEntity<Link, io.Link>, Link {
   @override
   ForwardingLink wrap(io.Link delegate) => wrapLink(delegate) as ForwardingLink;

--- a/packages/file/lib/src/forwarding/forwarding_link.dart
+++ b/packages/file/lib/src/forwarding/forwarding_link.dart
@@ -6,7 +6,7 @@ import 'package:file/src/io.dart' as io;
 import 'package:file/file.dart';
 
 /// A link that forwards all methods and properties to a delegate.
-abstract class ForwardingLink
+mixin ForwardingLink
     implements ForwardingFileSystemEntity<Link, io.Link>, Link {
   @override
   ForwardingLink wrap(io.Link delegate) => wrapLink(delegate) as ForwardingLink;

--- a/packages/file/lib/src/forwarding/forwarding_random_access_file.dart
+++ b/packages/file/lib/src/forwarding/forwarding_random_access_file.dart
@@ -10,7 +10,7 @@ import 'package:meta/meta.dart';
 
 /// A [RandomAccessFile] implementation that forwards all methods and properties
 /// to a delegate.
-abstract class ForwardingRandomAccessFile implements io.RandomAccessFile {
+mixin ForwardingRandomAccessFile implements io.RandomAccessFile {
   /// The entity to which this entity will forward all methods and properties.
   @protected
   io.RandomAccessFile get delegate;

--- a/packages/file/lib/src/forwarding/forwarding_random_access_file.dart
+++ b/packages/file/lib/src/forwarding/forwarding_random_access_file.dart
@@ -10,7 +10,7 @@ import 'package:meta/meta.dart';
 
 /// A [RandomAccessFile] implementation that forwards all methods and properties
 /// to a delegate.
-mixin ForwardingRandomAccessFile implements io.RandomAccessFile {
+abstract mixin class ForwardingRandomAccessFile implements io.RandomAccessFile {
   /// The entity to which this entity will forward all methods and properties.
   @protected
   io.RandomAccessFile get delegate;

--- a/packages/file/lib/src/forwarding/forwarding_random_access_file.dart
+++ b/packages/file/lib/src/forwarding/forwarding_random_access_file.dart
@@ -10,7 +10,7 @@ import 'package:meta/meta.dart';
 
 /// A [RandomAccessFile] implementation that forwards all methods and properties
 /// to a delegate.
-abstract mixin class ForwardingRandomAccessFile implements io.RandomAccessFile {
+mixin ForwardingRandomAccessFile implements io.RandomAccessFile {
   /// The entity to which this entity will forward all methods and properties.
   @protected
   io.RandomAccessFile get delegate;

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -7,7 +7,7 @@ description:
 repository: https://github.com/google/file.dart/tree/master/packages/file
 
 environment:
-  sdk: '>=3.0.0-321.0.dev <4.0.0'
+  sdk: '>=3.0.0-325.0.dev <4.0.0'
 
 dependencies:
   meta: ^1.9.1

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -7,13 +7,13 @@ description:
 repository: https://github.com/google/file.dart/tree/master/packages/file
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
-  meta: ^1.3.0
-  path: ^1.8.0
+  meta: ^1.9.0
+  path: ^1.8.3
 
 dev_dependencies:
   file_testing: ^3.0.0
-  lints: ^1.0.1
-  test: ^1.16.0
+  lints: ^2.0.1
+  test: ^1.23.1

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -7,7 +7,7 @@ description:
 repository: https://github.com/google/file.dart/tree/master/packages/file
 
 environment:
-  sdk: '>=3.0.0-356.0.dev <4.0.0'
+  sdk: '>=3.0.0-321.0.dev <4.0.0'
 
 dependencies:
   meta: ^1.9.1

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
 dev_dependencies:
   file_testing: ^3.0.0
   lints: ^2.0.1
-  test: ^1.23.1
+  test: ^1.24.0

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 7.0.0
+version: 6.2.0
 description:
   A pluggable, mockable file system abstraction for Dart. Supports local file
   system access, as well as in-memory file systems, record-replay file systems,

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
 dev_dependencies:
   file_testing: ^3.0.0
   lints: ^2.0.1
-  test: ^1.24.0
+  test: ^1.23.1

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 6.2.0
+version: 7.0.0
 description:
   A pluggable, mockable file system abstraction for Dart. Supports local file
   system access, as well as in-memory file systems, record-replay file systems,
@@ -7,7 +7,7 @@ description:
 repository: https://github.com/google/file.dart/tree/master/packages/file
 
 environment:
-  sdk: '>=3.0.0-325.0.dev <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   meta: ^1.9.1

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 7.0.0
+version: 7.0.0-wip
 description:
   A pluggable, mockable file system abstraction for Dart. Supports local file
   system access, as well as in-memory file systems, record-replay file systems,

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 6.1.4
+version: 7.0.0
 description:
   A pluggable, mockable file system abstraction for Dart. Supports local file
   system access, as well as in-memory file systems, record-replay file systems,

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -7,10 +7,10 @@ description:
 repository: https://github.com/google/file.dart/tree/master/packages/file
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.0.0-356.0.dev <4.0.0'
 
 dependencies:
-  meta: ^1.9.0
+  meta: ^1.9.1
   path: ^1.8.3
 
 dev_dependencies:

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -17,3 +17,6 @@ dev_dependencies:
   file_testing: ^3.0.0
   lints: ^2.0.1
   test: ^1.23.1
+
+dependency_overrides:
+  glob: 2.1.1

--- a/packages/file/test/common_tests.dart
+++ b/packages/file/test/common_tests.dart
@@ -502,7 +502,7 @@ void runCommonTests(
 
     group('Directory', () {
       test('uri', () {
-        expect(fs.directory(ns('/foo')).uri, fs.path.toUri(ns('/foo') + '/'));
+        expect(fs.directory(ns('/foo')).uri, fs.path.toUri('${ns('/foo')}/'));
         expect(fs.directory('foo').uri.toString(), 'foo/');
       });
 
@@ -2600,7 +2600,7 @@ void runCommonTests(
 
         test('isTrailingNewlineAgnostic', () {
           File f = fs.file(ns('/foo'))..createSync();
-          f.writeAsStringSync(testString + '\n');
+          f.writeAsStringSync('$testString\n');
           expect(f.readAsLinesSync(), expectedLines);
 
           f.writeAsStringSync('\n');

--- a/packages/file_testing/pubspec.yaml
+++ b/packages/file_testing/pubspec.yaml
@@ -4,10 +4,10 @@ description: Testing utilities for package:file.
 repository: https://github.com/google/file.dart/tree/master/packages/file_testing
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
-  test: ^1.16.0
+  test: ^1.23.1
 
 dev_dependencies: 
-  lints: ^1.0.1
+  lints: ^2.0.1

--- a/packages/file_testing/pubspec.yaml
+++ b/packages/file_testing/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=3.0.0-325.0.dev <4.0.0'
 
 dependencies:
-  test: ^1.24.0
+  test: ^1.23.1
 
 dev_dependencies: 
   lints: ^2.0.1

--- a/packages/file_testing/pubspec.yaml
+++ b/packages/file_testing/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=3.0.0-325.0.dev <4.0.0'
 
 dependencies:
-  test: ^1.23.1
+  test: ^1.24.0
 
 dev_dependencies: 
   lints: ^2.0.1

--- a/packages/file_testing/pubspec.yaml
+++ b/packages/file_testing/pubspec.yaml
@@ -4,7 +4,7 @@ description: Testing utilities for package:file.
 repository: https://github.com/google/file.dart/tree/master/packages/file_testing
 
 environment:
-  sdk: '>=3.0.0-321.0.dev <4.0.0'
+  sdk: '>=3.0.0-325.0.dev <4.0.0'
 
 dependencies:
   test: ^1.23.1

--- a/packages/file_testing/pubspec.yaml
+++ b/packages/file_testing/pubspec.yaml
@@ -11,3 +11,6 @@ dependencies:
 
 dev_dependencies: 
   lints: ^2.0.1
+
+dependency_overrides:
+  glob: 2.1.1

--- a/packages/file_testing/pubspec.yaml
+++ b/packages/file_testing/pubspec.yaml
@@ -4,7 +4,7 @@ description: Testing utilities for package:file.
 repository: https://github.com/google/file.dart/tree/master/packages/file_testing
 
 environment:
-  sdk: '>=3.0.0-356.0.dev <4.0.0'
+  sdk: '>=3.0.0-321.0.dev <4.0.0'
 
 dependencies:
   test: ^1.23.1

--- a/packages/file_testing/pubspec.yaml
+++ b/packages/file_testing/pubspec.yaml
@@ -4,7 +4,7 @@ description: Testing utilities for package:file.
 repository: https://github.com/google/file.dart/tree/master/packages/file_testing
 
 environment:
-  sdk: '>=3.0.0-325.0.dev <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   test: ^1.23.1

--- a/packages/file_testing/pubspec.yaml
+++ b/packages/file_testing/pubspec.yaml
@@ -4,7 +4,7 @@ description: Testing utilities for package:file.
 repository: https://github.com/google/file.dart/tree/master/packages/file_testing
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.0.0-356.0.dev <4.0.0'
 
 dependencies:
   test: ^1.23.1


### PR DESCRIPTION
Fix https://github.com/google/file.dart/issues/209

I also made sure `dart analyzer` result is perfect.

`abstract class` => `mixin`. They can't be `mixin class` because then they need to expose/re-implement dozens of methods.

![image](https://user-images.githubusercontent.com/351125/226994562-5d1f8653-a358-464b-b201-4edafdc47525.png)
