### PR TITLE
Fix MemoryFileSystem to treat an empty path as non-existent

### DIFF
--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 6.1.5
+
+* `MemoryFileSystem` now treats empty paths as non-existent.
+
 #### 6.1.4
 
 * Populate the pubspec `repository` field.

--- a/packages/file/lib/src/backends/memory/memory_file_system.dart
+++ b/packages/file/lib/src/backends/memory/memory_file_system.dart
@@ -197,9 +197,7 @@ class _MemoryFileSystem extends FileSystem
     return node.type;
   }
 
-  /// Gets the node backing for the current working directory. Note that this
-  /// can return null if the directory has been deleted or moved from under our
-  /// feet.
+  /// Gets the node backing for the current working directory.
   DirectoryNode get _current => findNode(cwd) as DirectoryNode;
 
   @override
@@ -211,7 +209,9 @@ class _MemoryFileSystem extends FileSystem
     List<String>? pathWithSymlinks,
     bool followTailLink = false,
   }) {
-    if (_context.isAbsolute(path)) {
+    if (path.isEmpty) {
+      return null;
+    } else if (_context.isAbsolute(path)) {
       reference = _root;
       path = path.substring(style.drive.length);
     } else {

--- a/packages/file/lib/src/backends/memory/memory_file_system.dart
+++ b/packages/file/lib/src/backends/memory/memory_file_system.dart
@@ -197,8 +197,10 @@ class _MemoryFileSystem extends FileSystem
     return node.type;
   }
 
-  /// Gets the node backing for the current working directory.
-  DirectoryNode get _current => findNode(cwd) as DirectoryNode;
+  /// Gets the node backing for the current working directory. Note that this
+  /// can return null if the directory has been deleted or moved from under our
+  /// feet.
+  DirectoryNode? get _current => findNode(cwd) as DirectoryNode?;
 
   @override
   Node? findNode(

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 6.1.4
+version: 6.1.5
 description:
   A pluggable, mockable file system abstraction for Dart. Supports local file
   system access, as well as in-memory file systems, record-replay file systems,

--- a/packages/file/test/common_tests.dart
+++ b/packages/file/test/common_tests.dart
@@ -370,6 +370,11 @@ void runCommonTests(
       });
 
       group('stat', () {
+        test('isNotFoundForEmptyPath', () {
+          FileStat stat = fs.statSync('');
+          expect(stat.type, FileSystemEntityType.notFound);
+        });
+
         test('isNotFoundForPathToNonExistentEntityAtTail', () {
           FileStat stat = fs.statSync(ns('/foo'));
           expect(stat.type, FileSystemEntityType.notFound);


### PR DESCRIPTION
`_MemoryFileSystem.findNode` returns `reference?.directory` if given the root path or an empty path.  However, an empty path should be treated as non-existent, not as a directory.  Instead explicitly return `null` as a special case when given an empty path.

Partially addresses https://github.com/google/file.dart/issues/198.