### PR TITLE
Make `FileSystem.isLink` actually work

### DIFF
--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 6.1.5
+
+* Fix `FileSystem.isLink`/`FileSystem.isLinkSync` to not follow symbolic links.
+
 #### 6.1.4
 
 * Populate the pubspec `repository` field.

--- a/packages/file/lib/src/interface/file_system.dart
+++ b/packages/file/lib/src/interface/file_system.dart
@@ -138,12 +138,12 @@ abstract class FileSystem {
 
   /// Checks if [`type(path)`](type) returns [io.FileSystemEntityType.LINK].
   Future<bool> isLink(String path) async =>
-      await type(path) == io.FileSystemEntityType.link;
+      await type(path, followLinks: false) == io.FileSystemEntityType.link;
 
   /// Synchronously checks if [`type(path)`](type) returns
   /// [io.FileSystemEntityType.LINK].
   bool isLinkSync(String path) =>
-      typeSync(path) == io.FileSystemEntityType.link;
+      typeSync(path, followLinks: false) == io.FileSystemEntityType.link;
 
   /// Gets the string path represented by the specified generic [path].
   ///

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file
-version: 6.1.4
+version: 6.1.5
 description:
   A pluggable, mockable file system abstraction for Dart. Supports local file
   system access, as well as in-memory file systems, record-replay file systems,

--- a/packages/file/test/common_tests.dart
+++ b/packages/file/test/common_tests.dart
@@ -498,6 +498,38 @@ void runCommonTests(
           expect(type, FileSystemEntityType.notFound);
         });
       });
+
+      test('isFileForFile', () {
+        fs.file(ns('/foo')).createSync();
+
+        expect(fs.isFileSync(ns('/foo')), true);
+        expect(fs.isDirectorySync(ns('/foo')), false);
+        expect(fs.isLinkSync(ns('/foo')), false);
+      });
+
+      test('isDirectoryForDirectory', () {
+        fs.directory(ns('/foo')).createSync();
+
+        expect(fs.isFileSync(ns('/foo')), false);
+        expect(fs.isDirectorySync(ns('/foo')), true);
+        expect(fs.isLinkSync(ns('/foo')), false);
+      });
+
+      test('isLinkForLink', () {
+        fs.file(ns('/file')).createSync();
+        fs.link(ns('/file-link')).createSync(ns('/file'));
+        fs.link(ns('/dir-link')).createSync(ns('/'));
+
+        expect(fs.isLinkSync(ns('/file')), false);
+
+        expect(fs.isFileSync(ns('/file-link')), true);
+        expect(fs.isDirectorySync(ns('/file-link')), false);
+        expect(fs.isLinkSync(ns('/file-link')), true);
+
+        expect(fs.isFileSync(ns('/dir-link')), false);
+        expect(fs.isDirectorySync(ns('/dir-link')), true);
+        expect(fs.isLinkSync(ns('/dir-link')), true);
+      });
     });
 
     group('Directory', () {

--- a/packages/file/test/common_tests.dart
+++ b/packages/file/test/common_tests.dart
@@ -499,36 +499,44 @@ void runCommonTests(
         });
       });
 
-      test('isFileForFile', () {
-        fs.file(ns('/foo')).createSync();
+      group('isFile/isDirectory/isLink', () {
+        late String filePath;
+        late String directoryPath;
+        late String fileLinkPath;
+        late String directoryLinkPath;
 
-        expect(fs.isFileSync(ns('/foo')), true);
-        expect(fs.isDirectorySync(ns('/foo')), false);
-        expect(fs.isLinkSync(ns('/foo')), false);
-      });
+        setUp(() {
+          filePath = ns('/file');
+          directoryPath = ns('/directory');
+          fileLinkPath = ns('/file-link');
+          directoryLinkPath = ns('/directory-link');
 
-      test('isDirectoryForDirectory', () {
-        fs.directory(ns('/foo')).createSync();
+          fs.file(filePath).createSync();
+          fs.directory(directoryPath).createSync();
+          fs.link(fileLinkPath).createSync(filePath);
+          fs.link(directoryLinkPath).createSync(directoryPath);
+        });
 
-        expect(fs.isFileSync(ns('/foo')), false);
-        expect(fs.isDirectorySync(ns('/foo')), true);
-        expect(fs.isLinkSync(ns('/foo')), false);
-      });
+        test('isFile', () {
+          expect(fs.isFileSync(filePath), true);
+          expect(fs.isFileSync(directoryPath), false);
+          expect(fs.isFileSync(fileLinkPath), true);
+          expect(fs.isFileSync(directoryLinkPath), false);
+        });
 
-      test('isLinkForLink', () {
-        fs.file(ns('/file')).createSync();
-        fs.link(ns('/file-link')).createSync(ns('/file'));
-        fs.link(ns('/dir-link')).createSync(ns('/'));
+        test('isDirectory', () {
+          expect(fs.isDirectorySync(filePath), false);
+          expect(fs.isDirectorySync(directoryPath), true);
+          expect(fs.isDirectorySync(fileLinkPath), false);
+          expect(fs.isDirectorySync(directoryLinkPath), true);
+        });
 
-        expect(fs.isLinkSync(ns('/file')), false);
-
-        expect(fs.isFileSync(ns('/file-link')), true);
-        expect(fs.isDirectorySync(ns('/file-link')), false);
-        expect(fs.isLinkSync(ns('/file-link')), true);
-
-        expect(fs.isFileSync(ns('/dir-link')), false);
-        expect(fs.isDirectorySync(ns('/dir-link')), true);
-        expect(fs.isLinkSync(ns('/dir-link')), true);
+        test('isLink', () {
+          expect(fs.isLinkSync(filePath), false);
+          expect(fs.isLinkSync(directoryPath), false);
+          expect(fs.isLinkSync(fileLinkPath), true);
+          expect(fs.isLinkSync(directoryLinkPath), true);
+        });
       });
     });
 


### PR DESCRIPTION
`FileSystem.isLink` called `FileSystem.type` with the default argument of `followLinks: true`.  This is obviously wrong since it would mean that `isLink` would never return true (except maybe for broken symbolic links).

Make `FileSystem.isLink` use `followLinks: false`.  This is what `dart:io`'s `FileSystemEntity.isLink` is documented to do.

Partially addresses https://github.com/google/file.dart/issues/8.