### PR TITLE
Make MemoryFile.openRead and _ChrootFile.openRead return Stream<List<int>> again

### DIFF
--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Dart 3 fixes for class modifiers.
 
+* Make the return type of `MemoryFile.openRead` and `_ChrootFile.openRead` again
+  match the return type from `dart:io`.
+
 #### 6.1.4
 
 * Populate the pubspec `repository` field.

--- a/packages/file/CHANGELOG.md
+++ b/packages/file/CHANGELOG.md
@@ -1,7 +1,6 @@
 #### 7.0.0-wip
 
 * Dart 3 fixes for class modifiers.
-
 * Make the return type of `MemoryFile.openRead` and `_ChrootFile.openRead` again
   match the return type from `dart:io`.
 

--- a/packages/file/lib/src/backends/chroot/chroot_file.dart
+++ b/packages/file/lib/src/backends/chroot/chroot_file.dart
@@ -251,8 +251,8 @@ class _ChrootFile extends _ChrootFileSystemEntity<File, io.File>
           path, getDelegate(followLinks: true).openSync(mode: mode));
 
   @override
-  Stream<Uint8List> openRead([int? start, int? end]) =>
-      getDelegate(followLinks: true).openRead(start, end).cast<Uint8List>();
+  Stream<List<int>> openRead([int? start, int? end]) =>
+      getDelegate(followLinks: true).openRead(start, end);
 
   @override
   IOSink openWrite({

--- a/packages/file/lib/src/backends/memory/memory_file.dart
+++ b/packages/file/lib/src/backends/memory/memory_file.dart
@@ -206,9 +206,9 @@ class MemoryFile extends MemoryFileSystemEntity implements File {
             ? content.sublist(start)
             : content.sublist(start, math.min(end, content.length));
       }
-      return Stream<List<int>>.fromIterable(<Uint8List>[content]);
+      return Stream.value(content);
     } catch (e) {
-      return Stream<List<int>>.fromFuture(Future<Uint8List>.error(e));
+      return Stream.error(e);
     }
   }
 

--- a/packages/file/lib/src/backends/memory/memory_file.dart
+++ b/packages/file/lib/src/backends/memory/memory_file.dart
@@ -196,7 +196,7 @@ class MemoryFile extends MemoryFileSystemEntity implements File {
   }
 
   @override
-  Stream<Uint8List> openRead([int? start, int? end]) {
+  Stream<List<int>> openRead([int? start, int? end]) {
     fileSystem.opHandle(path, FileSystemOp.open);
     try {
       FileNode node = resolvedBacking as FileNode;
@@ -206,9 +206,9 @@ class MemoryFile extends MemoryFileSystemEntity implements File {
             ? content.sublist(start)
             : content.sublist(start, math.min(end, content.length));
       }
-      return Stream<Uint8List>.fromIterable(<Uint8List>[content]);
+      return Stream<List<int>>.fromIterable(<Uint8List>[content]);
     } catch (e) {
-      return Stream<Uint8List>.fromFuture(Future<Uint8List>.error(e));
+      return Stream<List<int>>.fromFuture(Future<Uint8List>.error(e));
     }
   }
 

--- a/packages/file/pubspec.yaml
+++ b/packages/file/pubspec.yaml
@@ -19,4 +19,6 @@ dev_dependencies:
   test: ^1.23.1
 
 dependency_overrides:
+  # Temporary to break a dependency cycle.  See:
+  # <https://github.com/google/file.dart/pull/217#issuecomment-1530032688>
   glob: 2.1.1

--- a/packages/file/test/common_tests.dart
+++ b/packages/file/test/common_tests.dart
@@ -2228,6 +2228,21 @@ void runCommonTests(
           expect(f, isNot(exists));
           expect(newFile, exists);
         });
+
+        test('openReadCompatibleWithUtf8Decoder', () async {
+          const content = 'Hello world!';
+          File file = fs.file(ns('/foo'))
+            ..createSync()
+            ..writeAsStringSync(content);
+          expect(
+            await file
+                .openRead()
+                .transform(utf8.decoder)
+                .transform(const LineSplitter())
+                .first,
+            content,
+          );
+        });
       });
 
       group('openWrite', () {


### PR DESCRIPTION
This is equivalent to https://github.com/google/file.dart/pull/168, but I foolishly neglected to make corresponding changes for all file system types.

Fixes https://github.com/google/file.dart/issues/193.