### PR TITLE
Remove now unnecessary glob dependency override

### DIFF
--- a/packages/file_testing/CHANGELOG.md
+++ b/packages/file_testing/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 3.0.1-wip
+
+* Require Dart 3.0 or later.
+
 #### 3.0.0
 
 * Migrate to null safety.

--- a/packages/file_testing/pubspec.yaml
+++ b/packages/file_testing/pubspec.yaml
@@ -1,5 +1,5 @@
 name: file_testing
-version: 3.0.0
+version: 3.0.1-wip
 description: Testing utilities for package:file.
 repository: https://github.com/google/file.dart/tree/master/packages/file_testing
 
@@ -11,6 +11,3 @@ dependencies:
 
 dev_dependencies: 
   lints: ^2.0.1
-
-dependency_overrides:
-  glob: 2.1.1


### PR DESCRIPTION
This was required until `package:glob` supported `package:file` v7, which happened in glob 2.1.2: https://pub.dev/packages/glob/changelog#212