### PR TITLE
Fix chroot does not work on Windows

### DIFF
--- a/packages/file/lib/src/backends/chroot/chroot_file_system.dart
+++ b/packages/file/lib/src/backends/chroot/chroot_file_system.dart
@@ -231,7 +231,7 @@ class ChrootFileSystem extends FileSystem {
     } else {
       assert(path.isAbsolute(localPath));
     }
-    return '$root$localPath';
+    return path.join(root, path.relative(localPath, from: _localRoot));
   }
 
   /// Resolves symbolic links on [path] and returns the resulting resolved path.


### PR DESCRIPTION
Fix of dart-lang/tools#619.