### PR TITLE
update the repo readmes to indicate the new package locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Dart](https://github.com/google/file.dart/actions/workflows/file.yml/badge.svg)](https://github.com/google/file.dart/actions/workflows/file.yml)
+> [!NOTE]
+> The source-of-truth for these packages has moved to https://github.com/dart-lang/tools.
 
 A monorepo for the `package:file` and `package:file_testing` packages.
 

--- a/packages/file/README.md
+++ b/packages/file/README.md
@@ -1,5 +1,7 @@
-[![pub package](https://img.shields.io/pub/v/file.svg)](https://pub.dev/packages/file)
-[![package publisher](https://img.shields.io/pub/publisher/file.svg)](https://pub.dev/packages/file/publisher)
+> [!NOTE]
+> The source-of-truth for this package has moved to https://github.com/dart-lang/tools.
+
+## package:file
 
 A generic file system abstraction for Dart.
 

--- a/packages/file_testing/README.md
+++ b/packages/file_testing/README.md
@@ -1,4 +1,7 @@
-[![pub package](https://img.shields.io/pub/v/file_testing.svg)](https://pub.dev/packages/file_testing)
+> [!NOTE]
+> The source-of-truth for this package has moved to https://github.com/dart-lang/tools.
+
+## package:file_testing
 
 Testing utilities intended to work with `package:file`
 


### PR DESCRIPTION
- update the repo readmes to indicate the new package locations
- see https://github.com/google/file.dart/issues/244

(the source-of-truth is now https://github.com/dart-lang/tools)
